### PR TITLE
Feature/compound reward

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.2.2"
+version = "3.3.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -243,7 +243,8 @@ benchmarks! {
     }: _(RawOrigin::Root, true)
     enable_compound_staking {
         initialize::<T>();
-        let staker = whitelisted_caller();
+
+        let staker: T::AccountId = whitelisted_caller();
         let option = RewardHandling::OnlyPayout;
     }: _(RawOrigin::Signed(staker.clone()), option)
     verify {

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -212,6 +212,8 @@ benchmarks! {
         let claim_era = DappsStaking::<T>::current_era();
         let stakers = prepare_bond_and_stake::<T>(number_of_stakers, &contract_id, SEED)?;
         let staker = stakers[0].clone();
+
+        DappsStaking::<T>::set_reward_destination(RawOrigin::Signed(staker.clone()).into(), RewardDestination::StakeBalance)?;
         advance_to_era::<T>(claim_era + 1u32);
 
     }: claim_staker(RawOrigin::Signed(staker.clone()), contract_id.clone())

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -268,7 +268,7 @@ benchmarks! {
         let option = RewardDestination::FreeBalance;
     }: _(RawOrigin::Signed(staker.clone()), option)
     verify {
-        assert_last_event::<T>(Event::<T>::RewardDestinationSet(staker, option).into());
+        assert_last_event::<T>(Event::<T>::RewardDestination(staker, option).into());
     }
 
 }

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -241,6 +241,14 @@ benchmarks! {
 
     maintenance_mode {
     }: _(RawOrigin::Root, true)
+    enable_compound_staking {
+        initialize::<T>();
+        let staker = whitelisted_caller();
+        let option = RewardHandling::OnlyPayout;
+    }: _(RawOrigin::Signed(staker.clone()), option)
+    verify {
+        assert_last_event::<T>(Event::<T>::RewardHandlingChange(staker, option).into());
+    }
 
 }
 

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -241,14 +241,15 @@ benchmarks! {
 
     maintenance_mode {
     }: _(RawOrigin::Root, true)
-    enable_compound_staking {
+
+    set_reward_destination {
         initialize::<T>();
 
         let staker: T::AccountId = whitelisted_caller();
-        let option = RewardHandling::OnlyPayout;
+        let option = RewardDestination::FreeBalance;
     }: _(RawOrigin::Signed(staker.clone()), option)
     verify {
-        assert_last_event::<T>(Event::<T>::RewardHandlingChange(staker, option).into());
+        assert_last_event::<T>(Event::<T>::RewardChange(staker, option).into());
     }
 
 }

--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -266,8 +266,12 @@ benchmarks! {
     set_reward_destination {
         initialize::<T>();
 
-        let staker: T::AccountId = whitelisted_caller();
         let option = RewardDestination::FreeBalance;
+        let (_, contract_id) = register_contract::<T>()?;
+
+        let number_of_stakers = 1;
+        let stakers = prepare_bond_and_stake::<T>(number_of_stakers, &contract_id, SEED)?;
+        let staker = stakers[0].clone();
     }: _(RawOrigin::Signed(staker.clone()), option)
     verify {
         assert_last_event::<T>(Event::<T>::RewardDestination(staker, option).into());

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -60,7 +60,7 @@ impl<AccountId> DAppInfo<AccountId> {
     /// Create new `DAppInfo` struct instance with the given developer and state `Registered`
     fn new(developer: AccountId) -> Self {
         Self {
-            developer: developer,
+            developer,
             state: DAppState::Registered,
         }
     }
@@ -157,7 +157,7 @@ impl<Balance: AtLeast32BitUnsigned + Copy> EraStake<Balance> {
     }
 }
 
-/// Used to provide a compact and bounded storage for informatio about stakes in unclaimed eras.
+/// Used to provide a compact and bounded storage for information about stakes in unclaimed eras.
 ///
 /// In order to avoid creating a separate storage entry for each `(staker, contract, era)` triplet,
 /// this struct is used to provide a more memory efficient solution.
@@ -288,7 +288,7 @@ impl<Balance: AtLeast32BitUnsigned + Copy> StakerInfo<Balance> {
     /// `stakes: [<5, 1000>, <7, 1300>, <8, 0>, <15, 3000>]`
     ///
     /// 1. `claim()` will return `(5, 1000)`
-    ///     Interal vector is modified to `[<6, 1000>, <7, 1300>, <8, 0>, <15, 3000>]`
+    ///     Internal vector is modified to `[<6, 1000>, <7, 1300>, <8, 0>, <15, 3000>]`
     ///
     /// 2. `claim()` will return `(6, 1000)`.
     ///    Internal vector is modified to `[<7, 1300>, <8, 0>, <15, 3000>]`
@@ -439,9 +439,9 @@ where
 /// automatically restake anything they earn.
 #[derive(Encode, Decode, Clone, Copy, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub enum RewardDestination {
-    /// Rewards are transfered to stakers free balance without any further action.
+    /// Rewards are transferred to stakers free balance without any further action.
     FreeBalance,
-    /// Rewards are transfered to stakers balance and are immediately re-staked
+    /// Rewards are transferred to stakers balance and are immediately re-staked
     /// on the contract from which the reward was received.
     StakeBalance,
 }

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -466,7 +466,12 @@ pub struct AccountLedger<Balance: AtLeast32BitUnsigned + Default + Copy> {
 
 impl<Balance: AtLeast32BitUnsigned + Default + Copy> AccountLedger<Balance> {
     /// `true` if ledger is empty (no locked funds, no unbonding chunks), `false` otherwise.
-    pub(crate) fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.locked.is_zero() && self.unbonding_info.is_empty()
+    }
+
+    /// Configured reward destination
+    pub fn reward_destination(&self) -> RewardDestination {
+        self.reward_destination
     }
 }

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -329,7 +329,7 @@ impl<Balance: AtLeast32BitUnsigned + Copy> StakerInfo<Balance> {
 
     /// Latest staked value.
     /// E.g. if staker is fully unstaked, this will return `Zero`.
-    /// Othwerise returns a non-zero balance.
+    /// Otherwise returns a non-zero balance.
     pub fn latest_staked_value(&self) -> Balance {
         self.stakes.last().map_or(Zero::zero(), |x| x.staked)
     }

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -247,6 +247,8 @@ fn payout_block_rewards() {
         Balances::issue(STAKER_BLOCK_REWARD.into()),
         Balances::issue(DAPP_BLOCK_REWARD.into()),
     );
+}
+
 // Used to get a vec of all dapps staking events
 pub fn dapps_staking_events() -> Vec<crate::Event<TestRuntime>> {
     System::events()

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -247,4 +247,17 @@ fn payout_block_rewards() {
         Balances::issue(STAKER_BLOCK_REWARD.into()),
         Balances::issue(DAPP_BLOCK_REWARD.into()),
     );
+// Used to get a vec of all dapps staking events
+pub fn dapps_staking_events() -> Vec<crate::Event<TestRuntime>> {
+    System::events()
+        .into_iter()
+        .map(|r| r.event)
+        .filter_map(|e| {
+            if let Event::DappsStaking(inner) = e {
+                Some(inner)
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -130,6 +130,11 @@ pub mod pallet {
     #[pallet::getter(fn force_era)]
     pub type ForceEra<T> = StorageValue<_, Forcing, ValueQuery, ForceEraOnEmpty>;
 
+    /// Stores the block number of when the next era starts
+    #[pallet::storage]
+    #[pallet::getter(fn next_era_starting_block)]
+    pub type NextEraStartingBlock<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+
     /// Registered developer accounts points to corresponding contract
     #[pallet::storage]
     #[pallet::getter(fn registered_contract)]
@@ -141,12 +146,6 @@ pub mod pallet {
     #[pallet::getter(fn dapp_info)]
     pub(crate) type RegisteredDapps<T: Config> =
         StorageMap<_, Blake2_128Concat, T::SmartContract, DAppInfo<T::AccountId>>;
-
-    /// Legacy, don't use.
-    /// TODO: remove in future upgrades
-    #[pallet::storage]
-    pub type EraRewardsAndStakes<T: Config> =
-        StorageMap<_, Twox64Concat, EraIndex, migrations::v3::OldEraRewardAndStake<BalanceOf<T>>>;
 
     /// Total staked, locked & rewarded for a particular era
     #[pallet::storage]

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -221,7 +221,7 @@ pub mod pallet {
         /// Maintenance mode has been enabled or disabled
         MaintenanceMode(bool),
         /// Claimed staker reward restaked
-        RewardRestaked(T::AccountId, T::SmartContract, BalanceOf<T>),
+        RewardAndRestake(T::AccountId, T::SmartContract, BalanceOf<T>),
     }
 
     #[pallet::error]
@@ -276,10 +276,6 @@ pub mod pallet {
         RequiredContractPreApproval,
         /// Developer's account is already part of pre-approved list
         AlreadyPreApprovedDeveloper,
-        /// No ledger info for account
-        NothingStakedForAccount,
-        /// Reward handling already set to the requested value
-        RestakingAlreadySet,
     }
 
     #[pallet::hooks]
@@ -721,7 +717,7 @@ pub mod pallet {
 
                 ContractEraStake::<T>::insert(contract_id.clone(), current_era, staking_info);
 
-                Self::deposit_event(Event::<T>::RewardRestaked(
+                Self::deposit_event(Event::<T>::RewardAndRestake(
                     staker.clone(),
                     contract_id.clone(),
                     staker_reward,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -1031,7 +1031,7 @@ pub mod pallet {
         }
 
         // `true` if all the conditions for restaking the reward have been met, `false` otherwise
-        fn should_restake_reward(
+        pub(crate) fn should_restake_reward(
             reward_destination: RewardDestination,
             contract_id: &T::SmartContract,
             latest_staked_value: BalanceOf<T>,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -504,9 +504,19 @@ pub mod pallet {
             );
 
             // Increment ledger and total staker value for contract. Overflow shouldn't be possible but the check is here just for safety.
-            Self::stake(value_to_stake, &mut staker_info);
-            Self::add_ledger_locked(&staker, &mut ledger, value_to_stake);
-            Self::update_contract_era_stake(&mut staking_info, &contract_id, value_to_stake);
+            ensure!(
+                Self::stake(value_to_stake, &mut staker_info).is_ok(),
+                Error::<T>::UnexpectedStakeInfoEra
+            );
+            ensure!(
+                Self::add_ledger_locked(&staker, &mut ledger, value_to_stake).is_ok(),
+                ArithmeticError::Overflow
+            );
+            ensure!(
+                Self::update_contract_era_stake(&mut staking_info, &contract_id, value_to_stake)
+                    .is_ok(),
+                ArithmeticError::Overflow
+            );
             Self::update_staker_info(&staker, &contract_id, staker_info.clone());
 
             Self::deposit_event(Event::<T>::BondAndStake(
@@ -695,9 +705,19 @@ pub mod pallet {
 
             let mut ledger = Self::ledger(&staker);
             if let RewardHandling::PayoutAndStake = ledger.reward_handling {
-                Self::stake(staker_reward, &mut staker_info);
-                Self::add_ledger_locked(&staker, &mut ledger, staker_reward);
-                Self::update_contract_era_stake(&mut staking_info, &contract_id, staker_reward);
+                ensure!(
+                    Self::stake(staker_reward, &mut staker_info).is_ok(),
+                    Error::<T>::UnexpectedStakeInfoEra
+                );
+                ensure!(
+                    Self::add_ledger_locked(&staker, &mut ledger, staker_reward).is_ok(),
+                    ArithmeticError::Overflow
+                );
+                ensure!(
+                    Self::update_contract_era_stake(&mut staking_info, &contract_id, staker_reward)
+                        .is_ok(),
+                    ArithmeticError::Overflow
+                );
             }
             Self::update_staker_info(&staker, &contract_id, staker_info.clone());
             Ok(().into())

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -747,11 +747,12 @@ pub mod pallet {
             Self::update_staker_info(&staker, &contract_id, staker_info);
             Self::deposit_event(Event::<T>::Reward(staker, contract_id, era, staker_reward));
 
-            if should_restake_reward {
-                Ok(Some(T::WeightInfo::claim_staker_with_restake()).into())
+            Ok(Some(if should_restake_reward {
+                T::WeightInfo::claim_staker_with_restake()
             } else {
-                Ok(Some(T::WeightInfo::claim_staker_without_restake()).into())
-            }
+                T::WeightInfo::claim_staker_without_restake()
+            })
+            .into())
         }
 
         /// Claim earned dapp rewards for the specified era.

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -732,14 +732,14 @@ pub mod pallet {
                     contract_id.clone(),
                     staker_reward,
                 ));
-            } else {
-                Self::deposit_event(Event::<T>::Reward(
-                    staker.clone(),
-                    contract_id.clone(),
-                    era,
-                    staker_reward,
-                ));
             }
+
+            Self::deposit_event(Event::<T>::Reward(
+                staker.clone(),
+                contract_id.clone(),
+                era,
+                staker_reward,
+            ));
             Self::update_staker_info(&staker, &contract_id, staker_info);
             Ok(().into())
         }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -223,7 +223,7 @@ pub mod pallet {
         /// Claimed staker reward restaked
         RewardAndRestake(T::AccountId, T::SmartContract, BalanceOf<T>),
         /// Reward handling modified
-        RewardHandlingChange(T::AccountId, RewardHandling),
+        RewardDestinationChange(T::AccountId, RewardDestination),
     }
 
     #[pallet::error]
@@ -701,7 +701,7 @@ pub mod pallet {
 
             let mut ledger = Self::ledger(&staker);
 
-            if ledger.reward_handling == RewardHandling::PayoutAndStake
+            if ledger.reward_destination == RewardDestination::StakeBalance
                 && !staker_info.latest_staked_value().is_zero()
             {
                 staker_info
@@ -866,21 +866,20 @@ pub mod pallet {
 
             Self::deposit_event(Event::<T>::MaintenanceMode(enable_maintenance));
 
-            #[pallet::weight(T::WeightInfo::enable_compound_staking())]
-            pub fn enable_compound_staking(
-                origin: OriginFor<T>,
-                option: RewardHandling,
-            ) -> DispatchResultWithPostInfo {
-                ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
-                let staker = ensure_signed(origin)?;
+        #[pallet::weight(T::WeightInfo::set_reward_destination())]
+        pub fn set_reward_destination(
+            origin: OriginFor<T>,
+            option: RewardDestination,
+        ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
+            let staker = ensure_signed(origin)?;
 
-                Ledger::<T>::mutate(&staker, |ledger| {
-                    ledger.reward_handling = option;
-                });
+            Ledger::<T>::mutate(&staker, |ledger| {
+                ledger.reward_destination = option;
+            });
 
-                Self::deposit_event(Event::<T>::RewardHandlingChange(staker, option));
-                Ok(().into())
-            }
+            Self::deposit_event(Event::<T>::RewardDestinationChange(staker, option));
+            Ok(().into())
         }
     }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -949,7 +949,7 @@ pub mod pallet {
         /// and stores it for future distribution
         ///
         /// This is called just at the beginning of an era.
-        fn reward_balance_snapshot(era: EraIndex, reward: BalanceOf<T>) {
+        fn reward_balance_snapshot(era: EraIndex, rewards: RewardInfo<BalanceOf<T>>) {
             // Get the reward and stake information for previous era
             let mut era_info = Self::general_era_info(era).unwrap_or_default();
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -709,6 +709,12 @@ pub mod pallet {
             if ledger.reward_destination == RewardDestination::StakeBalance
                 && !staker_info.latest_staked_value().is_zero()
             {
+                // There must be one slot left for restaking
+                ensure!(
+                    staker_info.len() < T::MaxEraStakeValues::get(),
+                    Error::<T>::TooManyEraStakeValues
+                );
+
                 staker_info
                     .stake(current_era, staker_reward)
                     .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -219,6 +219,8 @@ pub mod pallet {
         Reward(T::AccountId, T::SmartContract, EraIndex, BalanceOf<T>),
         /// Maintenance mode has been enabled or disabled
         MaintenanceMode(bool),
+        /// Claimed staker reward restaked
+        RewardRestaked(T::AccountId, T::SmartContract, BalanceOf<T>),
     }
 
     #[pallet::error]
@@ -718,6 +720,11 @@ pub mod pallet {
                         .is_ok(),
                     ArithmeticError::Overflow
                 );
+                Self::deposit_event(Event::<T>::RewardRestaked(
+                    staker.clone(),
+                    contract_id.clone(),
+                    staker_reward,
+                ));
             }
             Self::update_staker_info(&staker, &contract_id, staker_info.clone());
             Ok(().into())

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -901,10 +901,7 @@ pub mod pallet {
             let staker = ensure_signed(origin)?;
             let mut ledger = Self::ledger(&staker);
 
-            ensure!(
-                !ledger.is_empty(),
-                Error::<T>::NotActiveStaker
-            );
+            ensure!(!ledger.is_empty(), Error::<T>::NotActiveStaker);
 
             // this is done directly instead of using update_ledger helper
             // because there's no need to interact with the Currency locks

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -523,7 +523,7 @@ pub mod pallet {
 
             Self::update_ledger(&staker, ledger);
             Self::update_staker_info(&staker, &contract_id, staker_info);
-            ContractEraStake::<T>::insert(contract_id.clone(), current_era, staking_info);
+            ContractEraStake::<T>::insert(&contract_id, current_era, staking_info);
 
             Self::deposit_event(Event::<T>::BondAndStake(
                 staker,
@@ -697,7 +697,7 @@ pub mod pallet {
 
             if Self::should_restake_reward(
                 ledger.reward_destination,
-                &contract_id,
+                dapp_info.state,
                 staker_info.latest_staked_value(),
             ) {
                 // There must be one slot left for restaking
@@ -1035,11 +1035,11 @@ pub mod pallet {
         // `true` if all the conditions for restaking the reward have been met, `false` otherwise
         pub(crate) fn should_restake_reward(
             reward_destination: RewardDestination,
-            contract_id: &T::SmartContract,
+            dapp_state: DAppState,
             latest_staked_value: BalanceOf<T>,
         ) -> bool {
             reward_destination == RewardDestination::StakeBalance
-                && Self::is_active(contract_id)
+                && dapp_state == DAppState::Registered
                 && latest_staked_value > Zero::zero()
         }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -663,7 +663,7 @@ pub mod pallet {
         // TODO: do we need to add force methods or at least methods that allow others to claim for someone else?
 
         /// Claim earned staker rewards for the oldest era.
-        #[pallet::weight(T::WeightInfo::claim_staker())]
+        #[pallet::weight(T::WeightInfo::claim_staker_with_restake().max(T::WeightInfo::claim_staker_without_restake()))]
         pub fn claim_staker(
             origin: OriginFor<T>,
             contract_id: T::SmartContract,
@@ -750,7 +750,11 @@ pub mod pallet {
                 staker_reward,
             ));
             Self::update_staker_info(&staker, &contract_id, staker_info);
-            Ok(().into())
+            Ok(Some(
+                T::WeightInfo::claim_staker_with_restake()
+                    .max(T::WeightInfo::claim_staker_without_restake()),
+            )
+            .into())
         }
 
         /// Claim earned dapp rewards for the specified era.

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -222,6 +222,8 @@ pub mod pallet {
         MaintenanceMode(bool),
         /// Claimed staker reward restaked
         RewardAndRestake(T::AccountId, T::SmartContract, BalanceOf<T>),
+        /// Reward handling modified
+        RewardHandlingChange(T::AccountId, RewardHandling),
     }
 
     #[pallet::error]
@@ -875,6 +877,8 @@ pub mod pallet {
             Ledger::<T>::mutate(&staker, |ledger| {
                 ledger.reward_handling = option;
             });
+
+            Self::deposit_event(Event::<T>::RewardHandlingChange(staker, option));
             Ok(().into())
         }
     }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -220,8 +220,6 @@ pub mod pallet {
         Reward(T::AccountId, T::SmartContract, EraIndex, BalanceOf<T>),
         /// Maintenance mode has been enabled or disabled
         MaintenanceMode(bool),
-        /// Claimed staker reward restaked
-        RewardAndRestake(T::AccountId, T::SmartContract, BalanceOf<T>),
         /// Reward handling modified
         RewardDestinationSet(T::AccountId, RewardDestination),
     }
@@ -726,7 +724,7 @@ pub mod pallet {
 
                 ContractEraStake::<T>::insert(contract_id.clone(), current_era, staking_info);
 
-                Self::deposit_event(Event::<T>::RewardAndRestake(
+                Self::deposit_event(Event::<T>::BondAndStake(
                     staker.clone(),
                     contract_id.clone(),
                     staker_reward,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -275,6 +275,8 @@ pub mod pallet {
         RequiredContractPreApproval,
         /// Developer's account is already part of pre-approved list
         AlreadyPreApprovedDeveloper,
+        /// Account is not actively staking
+        NotActiveStaker,
     }
 
     #[pallet::hooks]
@@ -897,6 +899,11 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
             let staker = ensure_signed(origin)?;
+
+            ensure!(
+                Ledger::<T>::contains_key(&staker),
+                Error::<T>::NotActiveStaker
+            );
 
             Ledger::<T>::mutate(&staker, |ledger| {
                 ledger.reward_destination = reward_destination;

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -896,7 +896,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             reward_destination: RewardDestination,
         ) -> DispatchResultWithPostInfo {
-            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
+            Self::ensure_pallet_enabled()?;
             let staker = ensure_signed(origin)?;
 
             Ledger::<T>::mutate(&staker, |ledger| {
@@ -914,7 +914,7 @@ pub mod pallet {
             T::PalletId::get().into_account()
         }
 
-        /// `Ok` if pallet disabled for maintenance, `Err` otherwise
+        /// `Err` if pallet disabled for maintenance, `Ok` otherwise
         pub fn ensure_pallet_enabled() -> Result<(), Error<T>> {
             if PalletDisabled::<T>::get() {
                 Err(Error::<T>::Disabled)

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -695,16 +695,6 @@ pub mod pallet {
             let staker_reward =
                 Perbill::from_rational(staked, staking_info.total) * stakers_joint_reward;
 
-            // Withdraw reward funds from the dapps staking pot
-            let reward_imbalance = T::Currency::withdraw(
-                &Self::account_id(),
-                staker_reward,
-                WithdrawReasons::TRANSFER,
-                ExistenceRequirement::AllowDeath,
-            )?;
-
-            T::Currency::resolve_creating(&staker, reward_imbalance);
-
             let mut ledger = Self::ledger(&staker);
 
             if Self::should_restake_reward(
@@ -742,6 +732,16 @@ pub mod pallet {
                     staker_reward,
                 ));
             }
+
+            // Withdraw reward funds from the dapps staking pot
+            let reward_imbalance = T::Currency::withdraw(
+                &Self::account_id(),
+                staker_reward,
+                WithdrawReasons::TRANSFER,
+                ExistenceRequirement::AllowDeath,
+            )?;
+
+            T::Currency::resolve_creating(&staker, reward_imbalance);
 
             Self::deposit_event(Event::<T>::Reward(
                 staker.clone(),

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -223,7 +223,7 @@ pub mod pallet {
         /// Claimed staker reward restaked
         RewardAndRestake(T::AccountId, T::SmartContract, BalanceOf<T>),
         /// Reward handling modified
-        RewardDestinationChange(T::AccountId, RewardDestination),
+        RewardDestinationSet(T::AccountId, RewardDestination),
     }
 
     #[pallet::error]
@@ -888,16 +888,16 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::set_reward_destination())]
         pub fn set_reward_destination(
             origin: OriginFor<T>,
-            option: RewardDestination,
+            reward_destination: RewardDestination,
         ) -> DispatchResultWithPostInfo {
             ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let staker = ensure_signed(origin)?;
 
             Ledger::<T>::mutate(&staker, |ledger| {
-                ledger.reward_destination = option;
+                ledger.reward_destination = reward_destination;
             });
 
-            Self::deposit_event(Event::<T>::RewardDestinationChange(staker, option));
+            Self::deposit_event(Event::<T>::RewardDestinationSet(staker, reward_destination));
             Ok(().into())
         }
     }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -702,9 +702,12 @@ pub mod pallet {
             );
 
             if should_restake_reward {
-                // There must be one slot left for restaking
+                staker_info
+                    .stake(current_era, staker_reward)
+                    .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;
+
                 ensure!(
-                    staker_info.len() < T::MaxEraStakeValues::get(),
+                    staker_info.len() <= T::MaxEraStakeValues::get(),
                     Error::<T>::TooManyEraStakeValues
                 );
             }
@@ -718,12 +721,9 @@ pub mod pallet {
             )?;
 
             if should_restake_reward {
-                staker_info
-                    .stake(current_era, staker_reward)
-                    .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;
-
                 ledger.locked = ledger.locked.saturating_add(staker_reward);
                 staking_info.total = staking_info.total.saturating_add(staker_reward);
+
                 // Update storage
                 GeneralEraInfo::<T>::mutate(&current_era, |value| {
                     if let Some(x) = value {

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -221,7 +221,7 @@ pub mod pallet {
         /// Maintenance mode has been enabled or disabled
         MaintenanceMode(bool),
         /// Reward handling modified
-        RewardDestinationSet(T::AccountId, RewardDestination),
+        RewardDestination(T::AccountId, RewardDestination),
     }
 
     #[pallet::error]
@@ -899,7 +899,7 @@ pub mod pallet {
                 ledger.reward_destination = reward_destination;
             });
 
-            Self::deposit_event(Event::<T>::RewardDestinationSet(staker, reward_destination));
+            Self::deposit_event(Event::<T>::RewardDestination(staker, reward_destination));
             Ok(().into())
         }
     }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -706,7 +706,10 @@ pub mod pallet {
             ));
 
             let mut ledger = Self::ledger(&staker);
-            if let RewardHandling::PayoutAndStake = ledger.reward_handling {
+            if let (RewardHandling::PayoutAndStake, false) = (
+                ledger.reward_handling,
+                staker_info.latest_staked_value().is_zero(),
+            ) {
                 ensure!(
                     Self::stake(staker_reward, &mut staker_info).is_ok(),
                     Error::<T>::UnexpectedStakeInfoEra

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -866,20 +866,21 @@ pub mod pallet {
 
             Self::deposit_event(Event::<T>::MaintenanceMode(enable_maintenance));
 
-        #[pallet::weight(T::WeightInfo::enable_compound_staking())]
-        pub fn enable_compound_staking(
-            origin: OriginFor<T>,
-            option: RewardHandling,
-        ) -> DispatchResultWithPostInfo {
-            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
-            let staker = ensure_signed(origin)?;
+            #[pallet::weight(T::WeightInfo::enable_compound_staking())]
+            pub fn enable_compound_staking(
+                origin: OriginFor<T>,
+                option: RewardHandling,
+            ) -> DispatchResultWithPostInfo {
+                ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
+                let staker = ensure_signed(origin)?;
 
-            Ledger::<T>::mutate(&staker, |ledger| {
-                ledger.reward_handling = option;
-            });
+                Ledger::<T>::mutate(&staker, |ledger| {
+                    ledger.reward_handling = option;
+                });
 
-            Self::deposit_event(Event::<T>::RewardHandlingChange(staker, option));
-            Ok(().into())
+                Self::deposit_event(Event::<T>::RewardHandlingChange(staker, option));
+                Ok(().into())
+            }
         }
     }
 
@@ -898,7 +899,6 @@ pub mod pallet {
             }
         }
 
-        fn stake(
         fn update_staking_values(
             value_to_stake: BalanceOf<T>,
             ledger: &mut AccountLedger<BalanceOf<T>>,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -887,6 +887,8 @@ pub mod pallet {
             Ok(().into())
         }
 
+        /// `StakeBalance` (default) means claimed amount gets restaked,
+        /// `FreeBalance` sets claiming without restaking
         #[pallet::weight(T::WeightInfo::set_reward_destination())]
         pub fn set_reward_destination(
             origin: OriginFor<T>,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -706,6 +706,8 @@ pub mod pallet {
                     .stake(current_era, staker_reward)
                     .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;
 
+                // Restaking will, in the worst case, remove one, and add one record,
+                // so it's fine if the vector is full
                 ensure!(
                     staker_info.len() <= T::MaxEraStakeValues::get(),
                     Error::<T>::TooManyEraStakeValues

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -440,7 +440,7 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
     ) {
         assert_eq!(
             second_last_event.clone(),
-            Event::<TestRuntime>::RewardAndRestake(claimer, contract_id.clone(), calculated_reward,)
+            Event::<TestRuntime>::BondAndStake(claimer, contract_id.clone(), calculated_reward,)
         );
         assert_eq!(
             init_state_claim_era.staker_info.latest_staked_value() + calculated_reward,

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -429,14 +429,10 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
     let final_state_claim_era = MemorySnapshot::all(claim_era, contract_id, claimer);
     let final_state_current_era = MemorySnapshot::all(current_era, contract_id, claimer);
 
-    // If out of bounds, should fail anyway, so panic as acceptable
+    // If there's less than 2 events, it should fail anyway, so panic as acceptable
     let events = dapps_staking_events();
     let second_last_event = &events[events.len() - 2];
 
-    // println!(
-    //     "eraInfo: {:#?}, {:#?}",
-    //     init_state_current_era.era_info, final_state_current_era.era_info
-    // );
     if DappsStaking::should_restake_reward(
         init_state_claim_era.ledger.reward_destination,
         contract_id,

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -435,7 +435,7 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
 
     if DappsStaking::should_restake_reward(
         init_state_claim_era.ledger.reward_destination,
-        contract_id,
+        init_state_claim_era.dapp_info.state,
         init_state_claim_era.staker_info.latest_staked_value(),
     ) {
         assert_eq!(

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -542,3 +542,22 @@ pub(crate) fn assert_claim_dapp(contract_id: &MockSmartContract<AccountId>, clai
     assert_eq!(init_state.staker_info, final_state.staker_info);
     assert_eq!(init_state.ledger, final_state.ledger);
 }
+
+pub(crate) fn assert_set_reward_destination(
+    account_id: AccountId,
+    reward_destination: RewardDestination,
+) {
+    assert_ok!(DappsStaking::set_reward_destination(
+        Origin::signed(account_id),
+        reward_destination
+    ));
+
+    System::assert_last_event(mock::Event::DappsStaking(Event::RewardDestinationSet(
+        account_id,
+        reward_destination,
+    )));
+
+    let ledger = Ledger::<TestRuntime>::get(&account_id);
+
+    assert_eq!(ledger.reward_destination, reward_destination);
+}

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -420,22 +420,26 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
         contract_id.clone(),
     ));
 
+    // If out of bounds, should fail anyway, so panic as acceptable
+    let events = dapps_staking_events();
+    let second_last_event = &events[events.len() - 2];
+    
+    // assert_ok!(matches!())
     if init_state.ledger.reward_destination == RewardDestination::StakeBalance
         && !init_state.staker_info.latest_staked_value().is_zero()
     {
-        System::assert_last_event(mock::Event::DappsStaking(Event::RewardAndRestake(
+        assert_eq!(second_last_event.clone(), Event::<TestRuntime>::RewardAndRestake(
             claimer,
             contract_id.clone(),
             calculated_reward,
-        )))
-    } else {
-        System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
-            claimer,
-            contract_id.clone(),
-            claim_era,
-            calculated_reward,
-        )));
+        ));
     }
+    System::assert_last_event(mock::Event::DappsStaking(Event::Reward(
+        claimer,
+        contract_id.clone(),
+        claim_era,
+        calculated_reward,
+    )));
     let final_state = MemorySnapshot::all(claim_era, &contract_id, claimer);
     assert_eq!(
         init_state.free_balance + calculated_reward,

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -548,7 +548,7 @@ pub(crate) fn assert_set_reward_destination(
         reward_destination
     ));
 
-    System::assert_last_event(mock::Event::DappsStaking(Event::RewardDestinationSet(
+    System::assert_last_event(mock::Event::DappsStaking(Event::RewardDestination(
         account_id,
         reward_destination,
     )));

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -1,4 +1,4 @@
-use super::{Event, *};
+use super::{pallet::pallet::Event, *};
 use frame_support::assert_ok;
 use mock::{EraIndex, *};
 use sp_runtime::{traits::AccountIdConversion, Perbill};
@@ -420,7 +420,7 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
         contract_id.clone(),
     ));
 
-    if init_state.ledger.reward_handling == RewardHandling::PayoutAndStake
+    if init_state.ledger.reward_destination == RewardDestination::StakeBalance
         && !init_state.staker_info.latest_staked_value().is_zero()
     {
         System::assert_last_event(mock::Event::DappsStaking(Event::RewardAndRestake(

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -69,7 +69,7 @@ pub(crate) fn assert_register(developer: AccountId, contract_id: &MockSmartContr
         developer
     ));
 
-    // Verify op is successfull
+    // Verify op is successful
     assert_ok!(DappsStaking::enable_developer_pre_approval(
         Origin::root(),
         false
@@ -259,7 +259,7 @@ pub(crate) fn assert_bond_and_stake(
     );
 }
 
-/// Used to perform start_unbonding with sucess and storage assertions.
+/// Used to perform start_unbonding with success and storage assertions.
 pub(crate) fn assert_unbond_and_unstake(
     staker: AccountId,
     contract_id: &MockSmartContract<AccountId>,
@@ -356,7 +356,7 @@ pub(crate) fn assert_unbond_and_unstake(
     assert_eq!(init_state.era_info.locked, final_state.era_info.locked);
 }
 
-/// Used to perform start_unbonding with sucess and storage assertions.
+/// Used to perform start_unbonding with success and storage assertions.
 pub(crate) fn assert_withdraw_unbonded(staker: AccountId) {
     let current_era = DappsStaking::current_era();
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -482,7 +482,11 @@ pub(crate) fn assert_claim_staker(claimer: AccountId, contract_id: &MockSmartCon
 
 // assert staked and locked states depending on should_restake_reward
 // returns should_restake_reward result so further checks can be made
-fn assert_restake_reward(init_state: &MemorySnapshot, final_state: &MemorySnapshot, reward: u128) {
+fn assert_restake_reward(
+    init_state: &MemorySnapshot,
+    final_state: &MemorySnapshot,
+    reward: Balance,
+) {
     if DappsStaking::should_restake_reward(
         init_state.ledger.reward_destination,
         init_state.dapp_info.state,

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1519,13 +1519,13 @@ fn claims_with_different_reward_destination_is_ok() {
 
         // disable compounding mode, wait 3 eras
         assert_set_reward_destination(staker, RewardDestination::FreeBalance);
-        advance_to_era(start_era + 3);
+        advance_to_era(start_era + 1);
         // ensure staker can claim rewards to wallet
         assert_claim_staker(staker, &contract_id);
 
         // enable compounding mode, wait 3 eras
         assert_set_reward_destination(staker, RewardDestination::StakeBalance);
-        advance_to_era(start_era + 3);
+        advance_to_era(start_era + 2);
         // ensure staker can claim with compounding
         assert_claim_staker(staker, &contract_id);
     })

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{pallet::pallet::Error, pallet::pallet::Event, *};
 use frame_support::{
-    assert_err, assert_noop, assert_ok,
+    assert_noop, assert_ok,
     traits::{OnInitialize, OnUnbalanced},
 };
 use mock::{Balances, MockSmartContract, *};
@@ -1459,14 +1459,17 @@ fn claim_only_payout_is_ok() {
         let staker = 2;
         let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
 
+        // stake some tokens
         let start_era = DappsStaking::current_era();
         assert_register(developer, &contract_id);
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
+        // disable reward restaking
         advance_to_era(start_era + 1);
         assert_set_reward_destination(staker, RewardDestination::FreeBalance);
 
+        // ensure it's claimed correctly
         assert_claim_staker(staker, &contract_id);
     })
 }
@@ -1552,7 +1555,7 @@ fn claiming_when_stakes_full_without_compounding_is_ok() {
         assert_claim_staker(staker_id, &contract_id);
 
         // claiming should not work because it can't stake any more
-        assert_err!(
+        assert_noop!(
             DappsStaking::claim_staker(Origin::signed(staker_id), contract_id),
             Error::<TestRuntime>::TooManyEraStakeValues
         );

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1,5 +1,8 @@
-use super::{Error, Event, *};
-use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
+use super::{pallet::pallet::Error, pallet::pallet::Event, *};
+use frame_support::{
+    assert_err, assert_noop, assert_ok,
+    traits::{OnInitialize, OnUnbalanced},
+};
 use mock::{Balances, MockSmartContract, *};
 use sp_core::H160;
 use sp_runtime::{
@@ -1476,25 +1479,91 @@ fn claim_with_zero_staked_is_ok() {
         let developer = 1;
         let staker = 2;
         let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
-
         let start_era = DappsStaking::current_era();
         assert_register(developer, &contract_id);
+
+        // stake some tokens and wait for an era
         let stake_value = 100;
         assert_bond_and_stake(staker, &contract_id, stake_value);
-
         advance_to_era(start_era + 1);
 
+        // ensure reward_destination is set tot StakeBalance
+        assert_set_reward_destination(staker, RewardDestination::StakeBalance);
+
+        // unstake all the tokens
         assert_unbond_and_unstake(staker, &contract_id, stake_value);
 
+        // ensure claimed value goes to claimer's free balance
         assert_claim_staker(staker, &contract_id);
     })
 }
 
 #[test]
-fn claiming_with_different_reward_destination_is_ok() {}
+fn claim_with_different_reward_destination_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 2;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // stake some tokens
+        let start_era = DappsStaking::current_era();
+        assert_register(developer, &contract_id);
+        let stake_value = 100;
+        assert_bond_and_stake(staker, &contract_id, stake_value);
+
+        // disable compounding mode, wait 3 eras
+        assert_set_reward_destination(staker, RewardDestination::FreeBalance);
+        advance_to_era(start_era + 3);
+        // ensure staker can claim rewards to wallet
+        assert_claim_staker(staker, &contract_id);
+
+        // enable compounding mode, wait 3 eras
+        assert_set_reward_destination(staker, RewardDestination::StakeBalance);
+        advance_to_era(start_era + 3);
+        // ensure staker can claim with compounding
+        assert_claim_staker(staker, &contract_id);
+    })
+}
 
 #[test]
-fn claiming_when_stakes_full_without_compounding_is_ok() {}
+fn claiming_when_stakes_full_without_compounding_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let staker_id = 1;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+        // Insert a contract under registered contracts.
+        assert_register(10, &contract_id);
+
+        // Stake with MAX_NUMBER_OF_STAKERS - 1 on the same contract. It must work.
+        let start_era = DappsStaking::current_era();
+        for offset in 1..MAX_ERA_STAKE_VALUES {
+            assert_bond_and_stake(staker_id, &contract_id, 100);
+            advance_to_era(start_era + offset * 5);
+        }
+
+        // Make sure reward_destination is set to StakeBalance
+        assert_set_reward_destination(staker_id, RewardDestination::StakeBalance);
+
+        // there's one more stake spot left by bond_and_stake
+        // it's filled by claiming and restaking once
+        assert_claim_staker(staker_id, &contract_id);
+
+        // claiming should not work because it can't stake any more
+        assert_err!(
+            DappsStaking::claim_staker(Origin::signed(staker_id), contract_id),
+            Error::<TestRuntime>::TooManyEraStakeValues
+        );
+
+        // set reward_destination to FreeBalance (disable restaking)
+        assert_set_reward_destination(staker_id, RewardDestination::FreeBalance);
+
+        // claiming should work again
+        assert_claim_staker(staker_id, &contract_id);
+    })
+}
 
 #[test]
 fn claim_dapp_with_zero_stake_periods_is_ok() {

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1550,11 +1550,11 @@ fn claiming_when_stakes_full_without_compounding_is_ok() {
         // Make sure reward_destination is set to StakeBalance
         assert_set_reward_destination(staker_id, RewardDestination::StakeBalance);
 
-        // there's one more stake spot left by bond_and_stake
-        // it's filled by claiming and restaking once
+        // claim and restake once, so there's a claim record for the for the current era in the stakes vec
         assert_claim_staker(staker_id, &contract_id);
 
-        // claiming should not work because it can't stake any more
+        // making another gap in eras and trying to claim and restake would exceed MAX_ERA_STAKE_VALUES
+        advance_to_era(MAX_ERA_STAKE_VALUES * 5);
         assert_noop!(
             DappsStaking::claim_staker(Origin::signed(staker_id), contract_id),
             Error::<TestRuntime>::TooManyEraStakeValues

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -243,7 +243,7 @@ fn new_era_forcing() {
         advance_to_era(3);
         let starting_era = mock::DappsStaking::current_era();
 
-        // call on_initilize. It is not last block in the era, but it should increment the era
+        // call on_initialize. It is not last block in the era, but it should increment the era
         <ForceEra<TestRuntime>>::put(Forcing::ForceNew);
         run_for_blocks(1);
 
@@ -636,7 +636,7 @@ fn withdraw_from_unregistered_when_nothing_is_staked() {
 }
 
 #[test]
-fn withdraw_from_unregistered_when_unclaimed_rewards_remaing() {
+fn withdraw_from_unregistered_when_unclaimed_rewards_remaining() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
 
@@ -1163,7 +1163,7 @@ fn withdraw_unbonded_full_vector_is_ok() {
             advance_to_era(DappsStaking::current_era() + 1);
         }
 
-        // Now clean up all that are eligible for cleanu-up
+        // Now clean up all that are eligible for clean-up
         assert_withdraw_unbonded(staker_id);
 
         // This is a sanity check for the test. Some chunks should remain, otherwise test isn't testing realistic unbonding period.
@@ -1462,10 +1462,7 @@ fn claim_only_payout_is_ok() {
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
         advance_to_era(start_era + 1);
-        assert_ok!(DappsStaking::set_reward_destination(
-            Origin::signed(staker),
-            RewardDestination::FreeBalance
-        ));
+        assert_set_reward_destination(staker, RewardDestination::FreeBalance);
 
         assert_claim_staker(staker, &contract_id);
     })
@@ -1492,6 +1489,12 @@ fn claim_with_zero_staked_is_ok() {
         assert_claim_staker(staker, &contract_id);
     })
 }
+
+#[test]
+fn claiming_with_different_reward_destination_is_ok() {}
+
+#[test]
+fn claiming_when_stakes_full_without_compounding_is_ok() {}
 
 #[test]
 fn claim_dapp_with_zero_stake_periods_is_ok() {

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1830,3 +1830,35 @@ pub fn extra_reward_for_the_first_era() {
         );
     })
 }
+
+fn should_restake_reward_util() {
+    // only passing case
+    let stake_registered_non_zero = DappsStaking::should_restake_reward(
+        RewardDestination::StakeBalance,
+        DAppState::Registered,
+        5000,
+    );
+    // false because of 0 last_staked_value
+    let stake_registered_zero = DappsStaking::should_restake_reward(
+        RewardDestination::StakeBalance,
+        DAppState::Registered,
+        0,
+    );
+    // false because of unregistered dapp state
+    let stake_unregistered = DappsStaking::should_restake_reward(
+        RewardDestination::StakeBalance,
+        DAppState::Unregistered(10),
+        1000,
+    );
+    // false because of reward destination
+    let free_registered = DappsStaking::should_restake_reward(
+        RewardDestination::FreeBalance,
+        DAppState::Registered,
+        1000,
+    );
+
+    assert!(stake_registered_non_zero);
+    assert!(!stake_registered_zero);
+    assert!(!stake_unregistered);
+    assert!(!free_registered);
+}

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1491,7 +1491,7 @@ fn claim_with_zero_staked_is_ok() {
         assert_bond_and_stake(staker, &contract_id, stake_value);
         advance_to_era(start_era + 1);
 
-        // ensure reward_destination is set tot StakeBalance
+        // ensure reward_destination is set to StakeBalance
         assert_set_reward_destination(staker, RewardDestination::StakeBalance);
 
         // unstake all the tokens
@@ -1541,7 +1541,7 @@ fn claiming_when_stakes_full_without_compounding_is_ok() {
         // Insert a contract under registered contracts.
         assert_register(10, &contract_id);
 
-        // Stake with MAX_NUMBER_OF_STAKERS - 1 on the same contract. It must work.
+        // Stake with MAX_ERA_STAKE_VALUES - 1 on the same contract. It must work.
         let start_era = DappsStaking::current_era();
         for offset in 1..MAX_ERA_STAKE_VALUES {
             assert_bond_and_stake(staker_id, &contract_id, 100);
@@ -1555,7 +1555,7 @@ fn claiming_when_stakes_full_without_compounding_is_ok() {
         assert_claim_staker(staker_id, &contract_id);
 
         // making another gap in eras and trying to claim and restake would exceed MAX_ERA_STAKE_VALUES
-        advance_to_era(MAX_ERA_STAKE_VALUES * 5);
+        advance_to_era(DappsStaking::current_era() + 1);
         assert_noop!(
             DappsStaking::claim_staker(Origin::signed(staker_id), contract_id),
             Error::<TestRuntime>::TooManyEraStakeValues

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1450,6 +1450,7 @@ fn claim_after_unregister_is_ok() {
         }
     })
 }
+
 #[test]
 fn claim_only_payout_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
@@ -1502,7 +1503,7 @@ fn claim_with_zero_staked_is_ok() {
 }
 
 #[test]
-fn claim_with_different_reward_destination_is_ok() {
+fn claims_with_different_reward_destination_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
 

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1567,6 +1567,21 @@ fn claiming_when_stakes_full_without_compounding_is_ok() {
 }
 
 #[test]
+fn changing_reward_destination_for_empty_ledger_is_not_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+        let staker = 1;
+        assert_noop!(
+            DappsStaking::set_reward_destination(
+                Origin::signed(staker),
+                RewardDestination::FreeBalance
+            ),
+            Error::<TestRuntime>::NotActiveStaker
+        );
+    });
+}
+
+#[test]
 fn claim_dapp_with_zero_stake_periods_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1,4 +1,4 @@
-use super::{pallet::pallet::Error, Event, *};
+use super::{Error, Event, *};
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{Balances, MockSmartContract, *};
 use sp_core::H160;
@@ -1462,9 +1462,9 @@ fn claim_only_payout_is_ok() {
         assert_bond_and_stake(staker, &contract_id, stake_value);
 
         advance_to_era(start_era + 1);
-        assert_ok!(DappsStaking::enable_compound_staking(
+        assert_ok!(DappsStaking::set_reward_destination(
             Origin::signed(staker),
-            RewardHandling::OnlyPayout
+            RewardDestination::FreeBalance
         ));
 
         assert_claim_staker(staker, &contract_id);

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -1,8 +1,5 @@
 use super::{pallet::pallet::Error, pallet::pallet::Event, *};
-use frame_support::{
-    assert_noop, assert_ok,
-    traits::{OnInitialize, OnUnbalanced},
-};
+use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
 use mock::{Balances, MockSmartContract, *};
 use sp_core::H160;
 use sp_runtime::{
@@ -1829,36 +1826,4 @@ pub fn extra_reward_for_the_first_era() {
             standard_staker_era_rewards
         );
     })
-}
-
-fn should_restake_reward_util() {
-    // only passing case
-    let stake_registered_non_zero = DappsStaking::should_restake_reward(
-        RewardDestination::StakeBalance,
-        DAppState::Registered,
-        5000,
-    );
-    // false because of 0 last_staked_value
-    let stake_registered_zero = DappsStaking::should_restake_reward(
-        RewardDestination::StakeBalance,
-        DAppState::Registered,
-        0,
-    );
-    // false because of unregistered dapp state
-    let stake_unregistered = DappsStaking::should_restake_reward(
-        RewardDestination::StakeBalance,
-        DAppState::Unregistered(10),
-        1000,
-    );
-    // false because of reward destination
-    let free_registered = DappsStaking::should_restake_reward(
-        RewardDestination::FreeBalance,
-        DAppState::Registered,
-        1000,
-    );
-
-    assert!(stake_registered_non_zero);
-    assert!(!stake_registered_zero);
-    assert!(!stake_unregistered);
-    assert!(!free_registered);
 }

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -7,20 +7,20 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet-dapps-staking.
 pub trait WeightInfo {
-    fn register() -> Weight;
-    fn unregister() -> Weight;
-    fn withdraw_from_unregistered() -> Weight;
-    fn enable_developer_pre_approval() -> Weight;
-    fn developer_pre_approval() -> Weight;
-    fn bond_and_stake() -> Weight;
-    fn unbond_and_unstake() -> Weight;
-    fn withdraw_unbonded() -> Weight;
-    fn claim_staker_without_restake() -> Weight;
-    fn claim_staker_with_restake() -> Weight;
-    fn claim_dapp() -> Weight;
-    fn force_new_era() -> Weight;
-		fn maintenance_mode() -> Weight;
-		fn set_reward_destination() -> Weight;
+	fn register() -> Weight;
+	fn unregister() -> Weight;
+	fn withdraw_from_unregistered() -> Weight;
+	fn enable_developer_pre_approval() -> Weight;
+	fn developer_pre_approval() -> Weight;
+	fn bond_and_stake() -> Weight;
+	fn unbond_and_unstake() -> Weight;
+	fn withdraw_unbonded() -> Weight;
+	fn claim_staker_without_restake() -> Weight;
+	fn claim_staker_with_restake() -> Weight;
+	fn claim_dapp() -> Weight;
+	fn force_new_era() -> Weight;
+	fn maintenance_mode() -> Weight;
+	fn set_reward_destination() -> Weight;
 }
 
 /// Weights for pallet_staking using the Substrate node and recommended hardware.
@@ -31,7 +31,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking RegisteredDapps (r:1 w:1)
 	// Storage: DappsStaking PreApprovalIsEnabled (r:1 w:0)
 	fn register() -> Weight {
-		(60_000_000 as Weight)
+		(32_139_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -40,34 +40,34 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn unregister() -> Weight {
-		(50_000_000 as Weight)
+		(31_929_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
-	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
+	// Storage: DappsStaking StakersInfo (r:1 w:1)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn withdraw_from_unregistered() -> Weight {
-		(69_000_000 as Weight)
+		(46_667_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking PreApprovalIsEnabled (r:0 w:1)
 	fn enable_developer_pre_approval() -> Weight {
-		(5_000_000 as Weight)
+		(2_745_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking PreApprovedDevelopers (r:1 w:1)
 	fn developer_pre_approval() -> Weight {
-		(8_000_000 as Weight)
+		(5_320_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
@@ -76,24 +76,24 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
-	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
+	// Storage: DappsStaking StakersInfo (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn bond_and_stake() -> Weight {
-		(98_000_000 as Weight)
+		(133_638_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
-	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
+	// Storage: DappsStaking StakersInfo (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn unbond_and_unstake() -> Weight {
-		(95_000_000 as Weight)
+		(134_480_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -103,7 +103,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn withdraw_unbonded() -> Weight {
-		(72_000_000 as Weight)
+		(114_252_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -117,7 +117,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn claim_staker_with_restake() -> Weight {
-		(91_000_000 as Weight)
+		(78_506_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(10 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
@@ -129,7 +129,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:0)
 	fn claim_staker_without_restake() -> Weight {
-		(56_000_000 as Weight)
+		(56_575_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
@@ -139,27 +139,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
 	fn claim_dapp() -> Weight {
-		(43_000_000 as Weight)
+		(31_619_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking ForceEra (r:0 w:1)
 	fn force_new_era() -> Weight {
-		(5_000_000 as Weight)
+		(2_815_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:1)
 	fn maintenance_mode() -> Weight {
-		(18_000_000 as Weight)
+		(10_970_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	fn set_reward_destination() -> Weight {
-		(24_000_000 as Weight)
+		(15_489_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
@@ -295,6 +295,7 @@ impl WeightInfo for () {
 	fn maintenance_mode() -> Weight {
 		(10_970_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -300,7 +300,7 @@ impl WeightInfo for () {
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	fn set_reward_destination() -> Weight {
 		(24_000_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -9,16 +9,17 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
     fn register() -> Weight;
     fn unregister() -> Weight;
-	fn withdraw_from_unregistered() -> Weight;
+    fn withdraw_from_unregistered() -> Weight;
     fn enable_developer_pre_approval() -> Weight;
     fn developer_pre_approval() -> Weight;
     fn bond_and_stake() -> Weight;
     fn unbond_and_unstake() -> Weight;
     fn withdraw_unbonded() -> Weight;
     fn claim_staker() -> Weight;
-	fn claim_dapp() -> Weight;
+    fn claim_dapp() -> Weight;
     fn force_new_era() -> Weight;
 	fn maintenance_mode() -> Weight;
+		fn enable_compound_staking() -> Weight;
 }
 
 /// Weights for pallet_staking using the Substrate node and recommended hardware.
@@ -109,12 +110,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking StakersInfo (r:1 w:1)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
-	// Storage: DappsStaking ContractEraStake (r:1 w:0)
-	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
+	// Storage: DappsStaking ContractEraStake (r:1 w:1)
+	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
+	// Storage: DappsStaking Ledger (r:1 w:1)
+	// Storage: DappsStaking EraRewardsAndStakes (r:1 w:0)
 	fn claim_staker() -> Weight {
-		(36_748_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(6 as Weight))
-			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+		(41_878_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(8 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
@@ -137,6 +140,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn maintenance_mode() -> Weight {
 		(10_970_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+		(1_192_000 as Weight)
+	}
+	// Storage: DappsStaking PalledDisabled (r:1 w:0)
+	// Storage: DappsStaking Ledger (r:1 w:1)
+	// TODO: get real base value
+	fn enable_compound_staking() -> Weight {
+		(3_466_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }
@@ -256,6 +267,14 @@ impl WeightInfo for () {
 	fn maintenance_mode() -> Weight {
 		(10_970_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
+		(1_192_000 as Weight)
+	}
+	// Storage: DappsStaking PalledDisabled (r:1 w:0)
+	// Storage: DappsStaking Ledger (r:1 w:1)
+	// TODO: get real base value
+	fn enable_compound_staking() -> Weight {
+		(3_466_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -15,7 +15,8 @@ pub trait WeightInfo {
     fn bond_and_stake() -> Weight;
     fn unbond_and_unstake() -> Weight;
     fn withdraw_unbonded() -> Weight;
-    fn claim_staker() -> Weight;
+    fn claim_staker_without_restake() -> Weight;
+    fn claim_staker_with_restake() -> Weight;
     fn claim_dapp() -> Weight;
     fn force_new_era() -> Weight;
 		fn maintenance_mode() -> Weight;
@@ -30,7 +31,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking RegisteredDapps (r:1 w:1)
 	// Storage: DappsStaking PreApprovalIsEnabled (r:1 w:0)
 	fn register() -> Weight {
-		(32_139_000 as Weight)
+		(60_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -39,34 +40,34 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: System Account (r:1 w:1)
 	fn unregister() -> Weight {
-		(31_929_000 as Weight)
+		(50_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
-	// Storage: DappsStaking StakersInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn withdraw_from_unregistered() -> Weight {
-		(46_667_000 as Weight)
+		(69_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking PreApprovalIsEnabled (r:0 w:1)
 	fn enable_developer_pre_approval() -> Weight {
-		(2_745_000 as Weight)
+		(5_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking PreApprovedDevelopers (r:1 w:1)
 	fn developer_pre_approval() -> Weight {
-		(5_320_000 as Weight)
+		(8_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
@@ -75,24 +76,24 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
-	// Storage: DappsStaking StakersInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	fn bond_and_stake() -> Weight {
-		(133_638_000 as Weight)
+		(98_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
-	// Storage: DappsStaking StakersInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn unbond_and_unstake() -> Weight {
-		(134_480_000 as Weight)
+		(95_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -102,22 +103,35 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
 	fn withdraw_unbonded() -> Weight {
-		(114_252_000 as Weight)
+		(72_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
-	// Storage: DappsStaking StakersInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
-	// Storage: DappsStaking GeneralEraInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralEraInfo (r:2 w:1)
 	// Storage: DappsStaking Ledger (r:1 w:1)
-	// Storage: DappsStaking EraRewardsAndStakes (r:1 w:0)
-	fn claim_staker() -> Weight {
-		(41_878_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	// Storage: Balances Locks (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	fn claim_staker_with_restake() -> Weight {
+		(91_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(10 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
+	}
+	// Storage: DappsStaking PalletDisabled (r:1 w:0)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
+	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
+	// Storage: DappsStaking CurrentEra (r:1 w:0)
+	// Storage: DappsStaking ContractEraStake (r:1 w:0)
+	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
+	// Storage: DappsStaking Ledger (r:1 w:0)
+	fn claim_staker_without_restake() -> Weight {
+		(56_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
@@ -125,28 +139,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: DappsStaking ContractEraStake (r:1 w:1)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
 	fn claim_dapp() -> Weight {
-		(31_619_000 as Weight)
+		(43_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking ForceEra (r:0 w:1)
 	fn force_new_era() -> Weight {
-		(2_815_000 as Weight)
+		(5_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:1)
 	fn maintenance_mode() -> Weight {
-		(10_970_000 as Weight)
+		(18_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-		.saturating_add(1_192_000 as Weight)
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
-	// Storage: DappsStaking PalledDisabled (r:1 w:0)
+	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
-	// TODO: get real base value
 	fn set_reward_destination() -> Weight {
-		(3_466_000 as Weight)
+		(24_000_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
@@ -236,14 +249,29 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
-	// Storage: DappsStaking StakersInfo (r:1 w:1)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
+	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
+	// Storage: DappsStaking CurrentEra (r:1 w:0)
+	// Storage: DappsStaking ContractEraStake (r:1 w:1)
+	// Storage: DappsStaking GeneralEraInfo (r:2 w:1)
+	// Storage: DappsStaking Ledger (r:1 w:1)
+	// Storage: Balances Locks (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	fn claim_staker_with_restake() -> Weight {
+		(91_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(10 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
+	}
+	// Storage: DappsStaking PalletDisabled (r:1 w:0)
+	// Storage: DappsStaking GeneralStakerInfo (r:1 w:1)
 	// Storage: DappsStaking RegisteredDapps (r:1 w:0)
 	// Storage: DappsStaking CurrentEra (r:1 w:0)
 	// Storage: DappsStaking ContractEraStake (r:1 w:0)
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
-	fn claim_staker() -> Weight {
-		(36_748_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
+	// Storage: DappsStaking Ledger (r:1 w:0)
+	fn claim_staker_without_restake() -> Weight {
+		(56_000_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
@@ -268,12 +296,11 @@ impl WeightInfo for () {
 		(10_970_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
 	}
-	// Storage: DappsStaking PalledDisabled (r:1 w:0)
+	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
-	// TODO: get real base value
 	fn set_reward_destination() -> Weight {
-		(3_466_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
+		(24_000_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
 	}
 }

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -258,7 +258,7 @@ impl WeightInfo for () {
 	// Storage: Balances Locks (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn claim_staker_with_restake() -> Weight {
-		(91_000_000 as Weight)
+		(78_506_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(10 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
 	}
@@ -270,7 +270,7 @@ impl WeightInfo for () {
 	// Storage: DappsStaking GeneralEraInfo (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:0)
 	fn claim_staker_without_restake() -> Weight {
-		(56_000_000 as Weight)
+		(56_575_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
@@ -299,7 +299,7 @@ impl WeightInfo for () {
 	// Storage: DappsStaking PalletDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	fn set_reward_destination() -> Weight {
-		(24_000_000 as Weight)
+		(15_489_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -18,8 +18,8 @@ pub trait WeightInfo {
     fn claim_staker() -> Weight;
     fn claim_dapp() -> Weight;
     fn force_new_era() -> Weight;
-	fn maintenance_mode() -> Weight;
-		fn enable_compound_staking() -> Weight;
+		fn maintenance_mode() -> Weight;
+		fn set_reward_destination() -> Weight;
 }
 
 /// Weights for pallet_staking using the Substrate node and recommended hardware.
@@ -140,12 +140,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn maintenance_mode() -> Weight {
 		(10_970_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(1 as Weight))
-		(1_192_000 as Weight)
+		.saturating_add(1_192_000 as Weight)
 	}
 	// Storage: DappsStaking PalledDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// TODO: get real base value
-	fn enable_compound_staking() -> Weight {
+	fn set_reward_destination() -> Weight {
 		(3_466_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
@@ -272,7 +272,7 @@ impl WeightInfo for () {
 	// Storage: DappsStaking PalledDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)
 	// TODO: get real base value
-	fn enable_compound_staking() -> Weight {
+	fn set_reward_destination() -> Weight {
 		(3_466_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))

--- a/frame/dapps-staking/src/weights.rs
+++ b/frame/dapps-staking/src/weights.rs
@@ -267,7 +267,6 @@ impl WeightInfo for () {
 	fn maintenance_mode() -> Weight {
 		(10_970_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(1 as Weight))
-		(1_192_000 as Weight)
 	}
 	// Storage: DappsStaking PalledDisabled (r:1 w:0)
 	// Storage: DappsStaking Ledger (r:1 w:1)

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.2.2"
+version = "3.3.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/precompiles/dapps-staking/DappsStaking.sol
+++ b/precompiles/dapps-staking/DappsStaking.sol
@@ -54,4 +54,13 @@ interface DappsStaking {
 
     /// @notice Claim one era of unclaimed dapp rewards for the specified contract and era.
     function claim_dapp(address, uint128) external;
+
+    /// Instruction how to handle reward payout for staker.
+    /// `FreeBalance` - Reward will be paid out to the staker (free balance).
+    /// `StakeBalance` - Reward will be paid out to the staker and is immediately restaked (locked balance)
+    enum RewardDestination {FreeBalance, StakeBalance}
+
+    /// @notice Set reward destination for staker rewards
+    /// @param reward_destination instruction on how the reward payout should be handled
+    function set_reward_destination(RewardDestination reward_destination) external;
 }

--- a/precompiles/dapps-staking/src/tests.rs
+++ b/precompiles/dapps-staking/src/tests.rs
@@ -5,6 +5,7 @@ use crate::mock::{
 use codec::{Decode, Encode};
 use fp_evm::{PrecompileFailure, PrecompileOutput};
 use frame_support::{assert_ok, dispatch::Dispatchable};
+use pallet_dapps_staking::RewardDestination;
 use pallet_evm::{ExitSucceed, PrecompileSet};
 use sha3::{Digest, Keccak256};
 use sp_core::H160;
@@ -404,6 +405,33 @@ fn bond_and_stake_ss58_is_ok() {
         });
 }
 
+#[test]
+fn set_reward_destination() {
+    ExternalityBuilder::default()
+        .with_balances(vec![
+            (TestAccount::Alex.into(), 200 * AST),
+            (TestAccount::Bobo.into(), 200 * AST),
+        ])
+        .build()
+        .execute_with(|| {
+            initialize_first_block();
+
+            // register contract and stake it
+            register_and_verify(TestAccount::Alex.into(), TEST_CONTRACT);
+
+            // bond & stake the origin contract
+            bond_stake_and_verify(TestAccount::Bobo, TEST_CONTRACT, 100 * AST);
+
+            // change destinations and verfiy it was successful
+            set_reward_destination_verify(TestAccount::Bobo.into(), RewardDestination::FreeBalance);
+            set_reward_destination_verify(
+                TestAccount::Bobo.into(),
+                RewardDestination::StakeBalance,
+            );
+            set_reward_destination_verify(TestAccount::Bobo.into(), RewardDestination::FreeBalance);
+        });
+}
+
 // ****************************************************************************************************
 // Helper functions
 // ****************************************************************************************************
@@ -581,6 +609,32 @@ fn withdraw_unbonded_verify(staker: AccountId32) {
         <TestRuntime as pallet_evm::Config>::Currency::free_balance(&staker),
         <TestRuntime as pallet_evm::Config>::Currency::usable_balance(&staker)
     );
+}
+
+/// helper function to verify change of reward destination for a staker
+fn set_reward_destination_verify(staker: AccountId32, reward_destination: RewardDestination) {
+    let selector = &Keccak256::digest(b"set_reward_destination(RewardDestination)")[0..4];
+
+    let mut input_data = Vec::<u8>::from([0u8; 36]);
+    input_data[0..4].copy_from_slice(&selector);
+
+    let reward_destination_raw: u8 = match reward_destination {
+        RewardDestination::FreeBalance => 0,
+        RewardDestination::StakeBalance => 1,
+    };
+    input_data[35] = reward_destination_raw;
+
+    // Read staker's ledger
+    let init_ledger = DappsStaking::ledger(&staker);
+    // Ensure that something is staked or being unbonded
+    assert!(!init_ledger.is_empty());
+
+    assert_ok!(
+        Call::Evm(evm_call(staker.clone().into(), input_data.to_vec())).dispatch(Origin::root())
+    );
+
+    let final_ledger = DappsStaking::ledger(&staker);
+    assert_eq!(final_ledger.reward_destination(), reward_destination);
 }
 
 /// helper function to bond, stake and verify if result is OK


### PR DESCRIPTION
**Pull Request Summary**

> Adds automatic restaking of reward to `claim_staker` extrinsic by checking the `ledger.reward_handling` property and staking the claimed amount right after claim.

**Check list**
- [ ] contains breaking changes
- [X] adds new feature
- [X] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [X] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- `ledger.reward_handling` check to `claim_staker`
- `RewardAndRestake`, `RewardHandlingChange` events
- `enable_compound_staking` extrinsic
- `update_staking_values` helper function
- tests to check claiming after unstake or manually switching `reward_handling`

**Fixes**
- fix `assert_claim_staker` test utility function to take into account `reward_handling` state 

**Changes**
- `claim_staker` now checks for `reward_handling` state, and restakes the claimed value if needed
- `bond_and_stake` uses `update_staking_values` helper function

**To-dos**
- [ ] update docs
