### PR TITLE
Update precompiles version due to tag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When a pallet has been modified (version in .toml is updated), a new release tag
 Naming format for the tag is:
 *pallet-name*-**toml-version**/polkadot-**version**
 
-E.g. `pallet-dapps-staking-1.1.2/polkadot-0.9.13`.
+E.g. `pallet-dapps-staking-1.1.2/polkadot-v0.9.13`.
 
 ## Further Reading
 

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
**Pull Request Summary**

* update precompiles dapps-staking version since a tag was already created for later version which relies on branch instead of tag
* update README.md versioning schema part to reflect what the script for tagging generates

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
