### PR TITLE
No-loop dapps-staking

### DIFF
--- a/frame/dapps-staking/src/benchmarking.rs
+++ b/frame/dapps-staking/src/benchmarking.rs
@@ -223,7 +223,7 @@ benchmarks! {
 
     }: _(RawOrigin::Signed(developer.clone()), contract_id.clone(), claim_era)
     verify {
-        let staking_info = DappsStaking::<T>::contract_era_stake(&contract_id, claim_era).unwrap();
+        let staking_info = DappsStaking::<T>::contract_stake_info(&contract_id, claim_era).unwrap();
         assert!(staking_info.contract_reward_claimed);
     }
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -982,8 +982,8 @@ pub mod pallet {
 
             for (contract_id, dapp_info) in RegisteredDapps::<T>::iter() {
                 // Ignore dapp if it was unregistered
+                consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().reads(1));
                 if let DAppState::Unregistered(_) = dapp_info.state {
-                    consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().reads(1));
                     continue;
                 }
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -24,7 +24,7 @@ impl MemorySnapshot {
             era_info: DappsStaking::general_era_info(era).unwrap(),
             dapp_info: RegisteredDapps::<TestRuntime>::get(contract_id).unwrap(),
             staker_info: GeneralStakerInfo::<TestRuntime>::get(&account, contract_id),
-            contract_info: DappsStaking::staking_info(contract_id, era),
+            contract_info: DappsStaking::contract_stake_info(contract_id, era).unwrap_or_default(),
             ledger: DappsStaking::ledger(&account),
             free_balance: <TestRuntime as Config>::Currency::free_balance(&account),
         }
@@ -37,7 +37,7 @@ impl MemorySnapshot {
             era_info: DappsStaking::general_era_info(era).unwrap(),
             dapp_info: RegisteredDapps::<TestRuntime>::get(contract_id).unwrap(),
             staker_info: Default::default(),
-            contract_info: DappsStaking::staking_info(contract_id, era),
+            contract_info: DappsStaking::contract_stake_info(contract_id, era).unwrap_or_default(),
             ledger: Default::default(),
             free_balance: Default::default(),
         }

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -131,7 +131,8 @@ where
 
         // call pallet-dapps-staking
         let staking_info =
-            pallet_dapps_staking::Pallet::<R>::staking_info(&contract_id, current_era);
+            pallet_dapps_staking::Pallet::<R>::contract_stake_info(&contract_id, current_era)
+                .unwrap_or_default();
         let gas_used = R::GasWeightMapping::weight_to_gas(R::DbWeight::get().read);
         // encode output with total
         let total = TryInto::<u128>::try_into(staking_info.total).unwrap_or(0);

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -131,7 +131,7 @@ where
 
         // call pallet-dapps-staking
         let staking_info =
-            pallet_dapps_staking::Pallet::<R>::contract_stake_info(&contract_id, current_era)
+            pallet_dapps_staking::Pallet::<R>::contract_era_stake(&contract_id, current_era)
                 .unwrap_or_default();
         let gas_used = R::GasWeightMapping::weight_to_gas(R::DbWeight::get().read);
         // encode output with total


### PR DESCRIPTION
**Pull Request Summary**

Removed _hidden_ iteration via for-loop from dapps-staking.
`iter_key_prefix()` reads in all keys which makes its usage very expensive and uncontrollable in weight and PoV size.

The idea behind this commit is to show a most simple solution on how this problem can be solved.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
