### PR TITLE
Fix an issue where a part of unbonding chunks would be skipped

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"


### PR DESCRIPTION
**Pull Request Summary**

Fixed an issue where we wouldn't account part of the unbonding info into TVL.
This was due to the addition operation being performed only when max allowed migration weight
has been exceeded.

This wouldn't have been a breaking change but we would have slightly incorrect TVL information.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata