### PR TITLE
Improvements for dapps-staking V3 migration

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -505,7 +505,7 @@ pub mod v3 {
 
     /// Used to fix the current inconsistent state we have on Shibuya.
     /// This code isn't reusable for other chains.
-    pub fn ccc<T: Config>() -> Weight {
+    pub fn shibuya_fix_for_v3<T: Config>() -> Weight {
         let current_era = Pallet::<T>::current_era();
         let previous_era = current_era - 1;
 

--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -483,6 +483,24 @@ pub mod v3 {
         Ok(().into())
     }
 
+    #[cfg(feature = "try-runtime")]
+    pub fn post_migrate_shibuya_fix_for_v3<T: Config>() -> Result<(), &'static str> {
+        // Ensure that all necessary `ContractEraStake` entries exist.
+        let current_era = Pallet::<T>::current_era();
+        for contract_id in RegisteredDapps::<T>::iter_keys() {
+            assert!(ContractEraStake::<T>::contains_key(
+                &contract_id,
+                current_era
+            ));
+            assert!(ContractEraStake::<T>::contains_key(
+                &contract_id,
+                current_era - 1
+            ));
+        }
+
+        Ok(().into())
+    }
+
     /// Used to fix the current inconsistent state we have on Shibuya.
     /// This code isn't reusable for other chains.
     pub fn shibuya_fix_for_v3<T: Config>() -> Weight {

--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -488,14 +488,16 @@ pub mod v3 {
         // Ensure that all necessary `ContractEraStake` entries exist.
         let current_era = Pallet::<T>::current_era();
         for contract_id in RegisteredDapps::<T>::iter_keys() {
-            assert!(ContractEraStake::<T>::contains_key(
-                &contract_id,
-                current_era
-            ));
-            assert!(ContractEraStake::<T>::contains_key(
-                &contract_id,
-                current_era - 1
-            ));
+            assert!(
+                !ContractEraStake::<T>::get(&contract_id, current_era)
+                    .unwrap()
+                    .contract_reward_claimed
+            );
+            assert!(
+                !ContractEraStake::<T>::get(&contract_id, current_era - 1)
+                    .unwrap()
+                    .contract_reward_claimed
+            );
         }
 
         Ok(().into())
@@ -503,7 +505,7 @@ pub mod v3 {
 
     /// Used to fix the current inconsistent state we have on Shibuya.
     /// This code isn't reusable for other chains.
-    pub fn shibuya_fix_for_v3<T: Config>() -> Weight {
+    pub fn ccc<T: Config>() -> Weight {
         let current_era = Pallet::<T>::current_era();
         let previous_era = current_era - 1;
 
@@ -1005,14 +1007,16 @@ pub mod v3 {
         // Ensure that all necessary `ContractEraStake` entries exist.
         let current_era = Pallet::<T>::current_era();
         for contract_id in RegisteredDapps::<T>::iter_keys() {
-            assert!(ContractEraStake::<T>::contains_key(
-                &contract_id,
-                current_era
-            ));
-            assert!(ContractEraStake::<T>::contains_key(
-                &contract_id,
-                current_era - 1
-            ));
+            assert!(
+                !ContractEraStake::<T>::get(&contract_id, current_era)
+                    .unwrap()
+                    .contract_reward_claimed
+            );
+            assert!(
+                !ContractEraStake::<T>::get(&contract_id, current_era - 1)
+                    .unwrap()
+                    .contract_reward_claimed
+            );
         }
 
         let ledger_count = Ledger::<T>::iter_keys().count() as u64;

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "1.2.1"
+version = "3.0.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,11 +15,13 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false }
-pallet-dapps-staking = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-dapps-staking-3.0.1/polkadot-v0.9.17", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17",  default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 num_enum = { version = "0.5.3", default-features = false }
 log = "0.4"
+
+# Astar
+pallet-dapps-staking = { path = "../../frame/dapps-staking", default-features = false }
 
 # Frontier
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.17", default-features = false }


### PR DESCRIPTION
**Pull Request Summary**

* fixed a bug where staker could get double reward for the last era (one time only)
* added additional limitation on number of `ContractEraStake` entries that can be processed to prevent huge PoV size

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
