### PR TITLE
Migration adaptation for unregistered contracts

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.0.3"
+version = "3.0.4"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -535,7 +535,7 @@ pub mod v3 {
         }
 
         log::info!("Executing a step of stateful storage migration.");
-        const CONTRACT_ERA_STAKE_READ_LIMIT: u32 = 8;
+        const CONTRACT_ERA_STAKE_READ_LIMIT: u32 = 64;
 
         let mut migration_state = MigrationStateV3::<T>::get();
         let mut consumed_weight = T::DbWeight::get().reads(2);
@@ -988,12 +988,15 @@ pub mod v3 {
             log::info!(">>> DAppInfo migration finished.");
         }
 
+        // Since enum was modified, we want to avoid corrupt data decoding
+        ForceEra::<T>::put(Forcing::NotForcing);
+
         MigrationStateV3::<T>::put(MigrationState::Finished);
         StorageVersion::<T>::put(Version::V3_0_0);
         PalletDisabled::<T>::put(false);
         log::info!(">>> Migration finalized.");
 
-        consumed_weight.saturating_add(T::DbWeight::get().writes(3))
+        consumed_weight.saturating_add(T::DbWeight::get().writes(4))
     }
 
     #[cfg(feature = "try-runtime")]

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.0.3"
+version = "3.0.4"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
**Pull Request Summary**

Adapts dapps-staking v3 migration logic to account for unregistered dapps.
This is needed for Shiden, unlike Shibuya which didn't have any unregistered dapps.

Code has been tested using `try-runtime` and works fine.

**TODO**
- [x] repeat manual test (just to be sure)
- [x] uplift version

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
