### PR TITLE
Staking festival end storage cleanup

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -46,9 +46,12 @@ impl MemorySnapshot {
 
 /// Used to fetch the free balance of dapps staking account
 pub(crate) fn free_balance_of_dapps_staking_account() -> Balance {
-    <TestRuntime as Config>::Currency::free_balance(
-        &<TestRuntime as Config>::PalletId::get().into_account(),
-    )
+    <TestRuntime as Config>::Currency::free_balance(&account_id())
+}
+
+/// Used to fetch pallet account Id
+pub(crate) fn account_id() -> AccountId {
+    <TestRuntime as Config>::PalletId::get().into_account()
 }
 
 /// Used to get total dapps reward for an era.

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
**Pull Request Summary**

Support for clearing old storage items from Astar once we end the staking festival.
Solution has been tested on local network and works fine.

### Upgrade Flow
1. Using `sudo`, unregister all contracts
2. Use binary built with `try-runtime` features to simulate runtime upgrade logic on Astar and confirm it works
3. Initiate runtime upgrade for Astar network with latest dapps-staking
4. Once new runtime is applied, pallet will enter **maintenance mode**
5. We will need to call `do_upgrade` call a few times in order to cleanup old storage items
6. Once last item is cleared, **maintenance mode** will be disabled an pallet will resume normal operation
7. :tada: :tada: :tada: we've re-launched!

**TODO**
- [x] beef up era 1 reward
- [x] decide unbonding period for Astar

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [x] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
