### PR TITLE
Fix incorrect function selector

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.3.0"
+version = "3.3.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -437,7 +437,7 @@ pub enum Action {
     WithdrawUnbounded = "withdraw_unbonded()",
     ClaimDapp = "claim_dapp(address,uint128)",
     ClaimStaker = "claim_staker(address)",
-    SetRewardDestination = "set_reward_destination(RewardDestination)",
+    SetRewardDestination = "set_reward_destination(uint8)",
 }
 
 impl<R> Precompile for DappsStakingWrapper<R>

--- a/precompiles/dapps-staking/src/tests.rs
+++ b/precompiles/dapps-staking/src/tests.rs
@@ -613,7 +613,7 @@ fn withdraw_unbonded_verify(staker: AccountId32) {
 
 /// helper function to verify change of reward destination for a staker
 fn set_reward_destination_verify(staker: AccountId32, reward_destination: RewardDestination) {
-    let selector = &Keccak256::digest(b"set_reward_destination(RewardDestination)")[0..4];
+    let selector = &Keccak256::digest(b"set_reward_destination(uint8)")[0..4];
 
     let mut input_data = Vec::<u8>::from([0u8; 36]);
     input_data[0..4].copy_from_slice(&selector);


### PR DESCRIPTION
**Pull Request Summary**

Fix for incorrect function selector in precompile dapps-staking.
Since enum is mapped to `uint8`, we should use that type instead.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
