### PR TITLE
Dapps-staking precompile: read staked amount on the contract

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.3.1"
+version = "3.3.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -167,7 +167,7 @@ pub mod pallet {
 
     #[pallet::storage]
     #[pallet::getter(fn staker_info)]
-    pub(crate) type GeneralStakerInfo<T: Config> = StorageDoubleMap<
+    pub type GeneralStakerInfo<T: Config> = StorageDoubleMap<
         _,
         Blake2_128Concat,
         T::AccountId,

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.3.1"
+version = "3.3.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/precompiles/dapps-staking/DappsStaking.sol
+++ b/precompiles/dapps-staking/DappsStaking.sol
@@ -29,6 +29,12 @@ interface DappsStaking {
     /// @return amount, Staked amount by the staker
     function read_staked_amount(bytes calldata staker) external view returns (uint128);
 
+    /// @notice Read Staked amount on a given contract for the staker
+    /// @param contract_id contract evm address
+    /// @param staker in form of 20 or 32 hex bytes
+    /// @return amount, Staked amount by the staker
+    function read_staked_amount_on_contract(address contract_id, bytes calldata staker) external view returns (uint128);
+
     /// @notice Read the staked amount from the era when the amount was last staked/unstaked
     /// @return total, The most recent total staked amount on contract
     function read_contract_stake(address contract_id) external view returns (uint128);


### PR DESCRIPTION
**Pull Request Summary**

> This functionality is an improvement. It adds possibility to read staked amount on the contract for the user (staker).
> Until now it was only possible to read if user (staker) is staking in general terms.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [x] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
