### PR TITLE
Change function modifier for ReadStakedAmountOnContract

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.3.2"
+version = "3.3.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 homepage = "https://astar.network/"

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.3.2"
+version = "3.3.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -512,6 +512,7 @@ where
                 | Action::ReadEraReward
                 | Action::ReadEraStaked
                 | Action::ReadStakedAmount
+                | Action::ReadStakedAmountOnContract
                 | Action::ReadContractStake => FunctionModifier::View,
                 _ => FunctionModifier::NonPayable,
             },


### PR DESCRIPTION
**Pull Request Summary**

When dapps-staking precompile `ReadStakedAmountOnContract` is called from other contract it fails with:
`(-32603) VM Exception while processing transaction: revert (can't call non-static function in static context)`
This is due to wrong function modifier for recently added `ReadStakedAmountOnContract`

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
