### PR TITLE
TakeRevenue implementation

### DIFF
--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcm-primitives"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Common XCM primitives used by runtimes"
 edition = "2021"

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -13,14 +13,17 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::weights::{constants::WEIGHT_PER_SECOND, Weight};
+use frame_support::{
+    traits::{tokens::fungibles, Get},
+    weights::{constants::WEIGHT_PER_SECOND, Weight},
+};
 use sp_runtime::traits::Bounded;
 use sp_std::{borrow::Borrow, marker::PhantomData};
 
 // Polkadot imports
 use xcm::latest::prelude::*;
 use xcm_builder::TakeRevenue;
-use xcm_executor::traits::{FilterAssetLocation, WeightTrader};
+use xcm_executor::traits::{FilterAssetLocation, MatchesFungibles, WeightTrader};
 
 use pallet_xc_asset_config::{ExecutionPaymentRate, XcAssetLocation};
 
@@ -197,6 +200,41 @@ impl FilterAssetLocation for ReserveAssetFilter {
             origin == reserve
         } else {
             false
+        }
+    }
+}
+
+/// Used to deposit XCM fees into a destination account.
+///
+/// Only handles fungible assets for now. If for any reason taking of the fee fails, it will be burned.
+///
+pub struct XcmFungibleFeeHandler<AccountId, Matcher, Assets, FeeDestination>(
+    sp_std::marker::PhantomData<(AccountId, Matcher, Assets, FeeDestination)>,
+);
+impl<
+        AccountId,
+        Assets: fungibles::Mutate<AccountId>,
+        Matcher: MatchesFungibles<Assets::AssetId, Assets::Balance>,
+        FeeDestination: Get<AccountId>,
+    > TakeRevenue for XcmFungibleFeeHandler<AccountId, Matcher, Assets, FeeDestination>
+{
+    fn take_revenue(revenue: MultiAsset) {
+        match Matcher::matches_fungibles(&revenue) {
+            Ok((asset_id, amount)) => {
+                // TODO: how to handle result? What if amount is zero - noop?
+                let _result = Assets::mint_into(asset_id, &FeeDestination::get(), amount);
+                log::trace!(
+                    target: "xcm::weight",
+                    "XcmFeeHandler::take_revenue took {:?} of asset Id {:?}",
+                    amount, asset_id,
+                );
+            }
+            Err(_) => {
+                log::debug!(
+                    target: "xcm::weight",
+                    "XcmFeeHandler:take_revenue failed to match fungible asset, it has been burned."
+                );
+            }
         }
     }
 }

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -207,8 +207,8 @@ impl FilterAssetLocation for ReserveAssetFilter {
 
 /// Used to deposit XCM fees into a destination account.
 ///
-/// Only handles fungible assets for now. If for any reason taking of the fee fails, it will be burned.
-/// Error trace will be printed.
+/// Only handles fungible assets for now.
+/// If for any reason taking of the fee fails, it will be burned and and error trace will be printed.
 ///
 pub struct XcmFungibleFeeHandler<AccountId, Matcher, Assets, FeeDestination>(
     sp_std::marker::PhantomData<(AccountId, Matcher, Assets, FeeDestination)>,

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `AssetLocationIdConverter` - conversion between local asset Id and cross-chain asset multilocation
 //! - `FixedRateOfForeignAsset` - weight trader for execution payment in foreign asset
 //! - `ReserveAssetFilter` - used to check whether asset/origin are a valid reserve location
+//! - `XcmFungibleFeeHandler` - used to handle XCM fee execution fees
 //!
 //! Please refer to implementation below for more info.
 //!
@@ -17,7 +18,7 @@ use frame_support::{
     traits::{tokens::fungibles, Get},
     weights::{constants::WEIGHT_PER_SECOND, Weight},
 };
-use sp_runtime::traits::Bounded;
+use sp_runtime::traits::{Bounded, Zero};
 use sp_std::{borrow::Borrow, marker::PhantomData};
 
 // Polkadot imports
@@ -207,6 +208,7 @@ impl FilterAssetLocation for ReserveAssetFilter {
 /// Used to deposit XCM fees into a destination account.
 ///
 /// Only handles fungible assets for now. If for any reason taking of the fee fails, it will be burned.
+/// Error trace will be printed.
 ///
 pub struct XcmFungibleFeeHandler<AccountId, Matcher, Assets, FeeDestination>(
     sp_std::marker::PhantomData<(AccountId, Matcher, Assets, FeeDestination)>,
@@ -221,16 +223,24 @@ impl<
     fn take_revenue(revenue: MultiAsset) {
         match Matcher::matches_fungibles(&revenue) {
             Ok((asset_id, amount)) => {
-                // TODO: how to handle result? What if amount is zero - noop?
-                let _result = Assets::mint_into(asset_id, &FeeDestination::get(), amount);
-                log::trace!(
-                    target: "xcm::weight",
-                    "XcmFeeHandler::take_revenue took {:?} of asset Id {:?}",
-                    amount, asset_id,
-                );
+                if amount > Zero::zero() {
+                    if let Err(error) = Assets::mint_into(asset_id, &FeeDestination::get(), amount)
+                    {
+                        log::error!(
+                            target: "xcm::weight",
+                            "XcmFeeHandler::take_revenue failed when minting asset: {:?}", error,
+                        );
+                    } else {
+                        log::trace!(
+                            target: "xcm::weight",
+                            "XcmFeeHandler::take_revenue took {:?} of asset Id {:?}",
+                            amount, asset_id,
+                        );
+                    }
+                }
             }
             Err(_) => {
-                log::debug!(
+                log::error!(
                     target: "xcm::weight",
                     "XcmFeeHandler:take_revenue failed to match fungible asset, it has been burned."
                 );


### PR DESCRIPTION
**Pull Request Summary**

Added `XcmFungibleFeeHandler` into `xcm-primitives`.
This can be used to deposit paid fees into a destination account instead of just burning them.

Tested locally with Shibuya:
```
2022-06-29 11:54:48.022 TRACE tokio-runtime-worker xcm::execute_xcm_in_credit: [Parachain] result: Ok(())    
2022-06-29 11:54:48.022 TRACE tokio-runtime-worker xcm::weight: [Parachain] XcmFeeHandler::take_revenue took 40000000000 of asset Id 300 
```

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
