### PR TITLE
Recover Erc20AssetsPrecompileSet new function

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,7 +1,7 @@
 name: Static Analysis
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 jobs:
   fmt:

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -99,7 +99,6 @@ pub trait AddressToAssetId<AssetId> {
 
 /// This means that every address that starts with 0xFFFFFFFF will go through an additional db read,
 /// but the probability for this to happen is 2^-32 for random addresses
-#[derive(Default)]
 pub struct Erc20AssetsPrecompileSet<Runtime, Instance: 'static = ()>(
     PhantomData<(Runtime, Instance)>,
 );

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -104,6 +104,12 @@ pub struct Erc20AssetsPrecompileSet<Runtime, Instance: 'static = ()>(
     PhantomData<(Runtime, Instance)>,
 );
 
+impl<Runtime, Instance> Erc20AssetsPrecompileSet<Runtime, Instance> {
+    pub fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
 impl<Runtime, Instance> PrecompileSet for Erc20AssetsPrecompileSet<Runtime, Instance>
 where
     Instance: 'static,


### PR DESCRIPTION
**Pull Request Summary**
new function was failing lint check, thus it was removed in the former PR.
Instead, Default derive was added.
https://github.com/AstarNetwork/astar-frame/pull/73/files#diff-a57fe059e97a2348d92ca778296fda9d73e137ca1dd8692e164451509b62401dL180

However, Runtime side was using new function and cannot compile if dependency updated, so we should recover it. 

<img width="1027" alt="Screen Shot 2022-07-14 at 20 58 29" src="https://user-images.githubusercontent.com/28953860/178977318-7be026c0-b6a6-4725-a27c-1f88169e07a2.png">

