### PR TITLE
Support for AccountKey20 in XCM precompiles

### DIFF
--- a/frame/block-reward/Cargo.toml
+++ b/frame/block-reward/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 homepage = "https://astar.network"
 repository = "https://github.com/AstarNetwork/Astar"
-description = "FRAME pallet for managing block reward issuance & distribution"
+description = "FRAME pallet for managing blcok reward issuance & distribution"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/frame/block-reward/Cargo.toml
+++ b/frame/block-reward/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 homepage = "https://astar.network"
 repository = "https://github.com/AstarNetwork/Astar"
-description = "FRAME pallet for managing blcok reward issuance & distribution"
+description = "FRAME pallet for managing block reward issuance & distribution"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-evm-precompile-xcm"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Basic XCM support for EVM."
 edition = "2021"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 log = "0.4.16"

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -8,7 +8,7 @@ interface XCM {
      * @dev Withdraw assets using PalletXCM call.
      * @param asset_id - list of XC20 asset addresses
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param recipient_account_id - AccountId of destination account
+     * @param recipient_account_id - SS58 public key of the destination account
      * @param is_relay - set `true` for using relay chain as reserve
      * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
      * @param fee_index - index of asset_id item that should be used as a XCM fee
@@ -22,6 +22,29 @@ interface XCM {
         address[] calldata asset_id,
         uint256[] calldata asset_amount,
         bytes32   recipient_account_id,
+        bool      is_relay,
+        uint256   parachain_id,
+        uint256   fee_index
+    ) external returns (bool);
+
+    /**
+     * @dev Withdraw assets using PalletXCM call.
+     * @param asset_id - list of XC20 asset addresses
+     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
+     * @param recipient_account_id - ETH address of the destination account
+     * @param is_relay - set `true` for using relay chain as reserve
+     * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
+     * @param fee_index - index of asset_id item that should be used as a XCM fee
+     * @return A boolean confirming whether the XCM message sent.
+     *
+     * How method check that assets list is valid:
+     * - all assets resolved to multi-location (on runtime level)
+     * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     */
+    function assets_withdraw(
+        address[] calldata asset_id,
+        uint256[] calldata asset_amount,
+        address   recipient_account_id,
         bool      is_relay,
         uint256   parachain_id,
         uint256   fee_index

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -4,7 +4,7 @@
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{AddressMapping, Precompile};
-use sp_core::{H256, U256};
+use sp_core::{H160, H256, U256};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 
@@ -25,7 +25,8 @@ mod tests;
 #[precompile_utils::generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
-    AssetsWithdraw = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
+    AssetsWithdrawSS58 = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
+    AssetsWithdrawH160 = "assets_withdraw(address[],uint256[],address,bool,uint256,uint256)",
 }
 
 /// A precompile that expose XCM related functions.
@@ -51,9 +52,18 @@ where
 
         match selector {
             // Dispatchables
-            Action::AssetsWithdraw => Self::assets_withdraw(handle),
+            Action::AssetsWithdrawSS58 => Self::assets_withdraw(handle, BeneficiaryType::SS58),
+            Action::AssetsWithdrawH160 => Self::assets_withdraw(handle, BeneficiaryType::H160),
         }
     }
+}
+
+/// The supported beneficiary account types
+enum BeneficiaryType {
+    /// 256 bit public key is expected
+    SS58,
+    /// 160 bit address is expected
+    H160,
 }
 
 impl<R, C> XcmPrecompile<R, C>
@@ -67,7 +77,10 @@ where
         From<pallet_xcm::Call<R>> + Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
     C: Convert<MultiLocation, <R as pallet_assets::Config>::AssetId>,
 {
-    fn assets_withdraw(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+    fn assets_withdraw(
+        handle: &mut impl PrecompileHandle,
+        beneficiary_type: BeneficiaryType,
+    ) -> EvmResult<PrecompileOutput> {
         let mut input = handle.read_input()?;
         input.expect_arguments(6)?;
 
@@ -93,7 +106,24 @@ where
             return Err(revert("Assets resolution failure."));
         }
 
-        let recipient: [u8; 32] = input.read::<H256>()?.into();
+        let beneficiary: MultiLocation = match beneficiary_type {
+            BeneficiaryType::SS58 => {
+                let recipient: [u8; 32] = input.read::<H256>()?.into();
+                X1(Junction::AccountId32 {
+                    network: Any,
+                    id: recipient,
+                })
+            }
+            BeneficiaryType::H160 => {
+                let recipient: H160 = input.read::<Address>()?.into();
+                X1(Junction::AccountKey20 {
+                    network: Any,
+                    key: recipient.to_fixed_bytes(),
+                })
+            }
+        }
+        .into();
+
         let is_relay = input.read::<bool>()?;
         let parachain_id: u32 = input.read::<U256>()?.low_u32();
         let fee_asset_item: u32 = input.read::<U256>()?.low_u32();
@@ -108,12 +138,6 @@ where
         } else {
             X1(Junction::Parachain(parachain_id)).into_exterior(1)
         };
-
-        let beneficiary: MultiLocation = X1(Junction::AccountId32 {
-            network: Any,
-            id: recipient,
-        })
-        .into();
 
         let assets: MultiAssets = assets
             .iter()

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -52,8 +52,12 @@ where
 
         match selector {
             // Dispatchables
-            Action::AssetsWithdrawNative => Self::assets_withdraw(handle, BeneficiaryType::AccountId32),
-            Action::AssetsWithdrawEvm => Self::assets_withdraw(handle, BeneficiaryType::AccountKey20),
+            Action::AssetsWithdrawNative => {
+                Self::assets_withdraw(handle, BeneficiaryType::AccountId32)
+            }
+            Action::AssetsWithdrawEvm => {
+                Self::assets_withdraw(handle, BeneficiaryType::AccountKey20)
+            }
         }
     }
 }

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -53,11 +53,9 @@ where
         match selector {
             // Dispatchables
             Action::AssetsWithdrawNative => {
-                Self::assets_withdraw(handle, BeneficiaryType::AccountId32)
+                Self::assets_withdraw(handle, BeneficiaryType::Account32)
             }
-            Action::AssetsWithdrawEvm => {
-                Self::assets_withdraw(handle, BeneficiaryType::AccountKey20)
-            }
+            Action::AssetsWithdrawEvm => Self::assets_withdraw(handle, BeneficiaryType::Account20),
         }
     }
 }
@@ -65,9 +63,9 @@ where
 /// The supported beneficiary account types
 enum BeneficiaryType {
     /// 256 bit (32 byte) public key
-    AccountId32,
+    Account32,
     /// 160 bit (20 byte) address is expected
-    AccountKey20,
+    Account20,
 }
 
 impl<R, C> XcmPrecompile<R, C>
@@ -111,14 +109,14 @@ where
         }
 
         let beneficiary: MultiLocation = match beneficiary_type {
-            BeneficiaryType::AccountId32 => {
+            BeneficiaryType::Account32 => {
                 let recipient: [u8; 32] = input.read::<H256>()?.into();
                 X1(Junction::AccountId32 {
                     network: Any,
                     id: recipient,
                 })
             }
-            BeneficiaryType::AccountKey20 => {
+            BeneficiaryType::Account20 => {
                 let recipient: H160 = input.read::<Address>()?.into();
                 X1(Junction::AccountKey20 {
                     network: Any,

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -16,7 +16,7 @@ fn wrong_assets_len_or_fee_index_reverts() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
                     .write(vec![Address::from(H160::repeat_byte(0xF1))])
                     .write(Vec::<U256>::new())
                     .write(H256::repeat_byte(0xF1))
@@ -32,7 +32,7 @@ fn wrong_assets_len_or_fee_index_reverts() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
                     .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
                     .write(vec![U256::from(42000u64)])
                     .write(H256::repeat_byte(0xF1))
@@ -49,14 +49,32 @@ fn wrong_assets_len_or_fee_index_reverts() {
 #[test]
 fn correct_arguments_works() {
     ExtBuilder::default().build().execute_with(|| {
+        // SS58
         precompiles()
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
                     .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
                     .write(vec![U256::from(42000u64)])
                     .write(H256::repeat_byte(0xF1))
+                    .write(true)
+                    .write(U256::from(0_u64))
+                    .write(U256::from(0_u64))
+                    .build(),
+            )
+            .expect_no_logs()
+            .execute_returns(EvmDataWriter::new().write(true).build());
+
+        // H160
+        precompiles()
+            .prepare_test(
+                TestAccount::Alice,
+                PRECOMPILE_ADDRESS,
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawH160)
+                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                    .write(vec![U256::from(42000u64)])
+                    .write(Address::from(H160::repeat_byte(0xDE)))
                     .write(true)
                     .write(U256::from(0_u64))
                     .write(U256::from(0_u64))

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -16,7 +16,7 @@ fn wrong_assets_len_or_fee_index_reverts() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
                     .write(vec![Address::from(H160::repeat_byte(0xF1))])
                     .write(Vec::<U256>::new())
                     .write(H256::repeat_byte(0xF1))
@@ -32,7 +32,7 @@ fn wrong_assets_len_or_fee_index_reverts() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
                     .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
                     .write(vec![U256::from(42000u64)])
                     .write(H256::repeat_byte(0xF1))
@@ -54,7 +54,7 @@ fn correct_arguments_works() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdrawSS58)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
                     .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
                     .write(vec![U256::from(42000u64)])
                     .write(H256::repeat_byte(0xF1))
@@ -71,7 +71,7 @@ fn correct_arguments_works() {
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdrawH160)
+                EvmDataWriter::new_with_selector(Action::AssetsWithdrawEvm)
                     .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
                     .write(vec![U256::from(42000u64)])
                     .write(Address::from(H160::repeat_byte(0xDE)))


### PR DESCRIPTION
**Pull Request Summary**

Adds support for ETH-style address to the XCM-precompile's withdraw function.
Legacy interface remains unchanged, instead a new function is added, as recommended.

One drawback to the current solution is that both H160 and SS58 are encoded as 256 bits.
This can be problematic since we cannot detect if user incorrectly withdraw for SS58 with H160 as beneficiary.

**Check list**
- [x] added unit tests
- [x] updated documentation
