### PR TITLE
dApps-Staking chain-extension - Reworked Errors

### DIFF
--- a/chain-extensions/impls/dapps-staking/Cargo.toml
+++ b/chain-extensions/impls/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapps-staking-chain-extension"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -86,11 +86,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 env.charge_weight(base_weight)?;
 
                 let era_index = pallet_dapps_staking::CurrentEra::<T>::get();
-                let write = env.write(&era_index.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&era_index.encode(), false, None)?;
             }
 
             DappsStakingFunc::UnbondingPeriod => {
@@ -98,11 +94,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 env.charge_weight(base_weight)?;
 
                 let unbonding_period = T::UnbondingPeriod::get();
-                let write = env.write(&unbonding_period.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&unbonding_period.encode(), false, None)?;
             }
 
             DappsStakingFunc::EraRewards => {
@@ -115,11 +107,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let reward = era_info.map_or(Zero::zero(), |r| {
                     r.rewards.stakers.saturating_add(r.rewards.dapps)
                 });
-                let write = env.write(&reward.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&reward.encode(), false, None)?;
             }
 
             DappsStakingFunc::EraStaked => {
@@ -130,11 +118,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
 
                 let era_info = pallet_dapps_staking::GeneralEraInfo::<T>::get(arg);
                 let staked_amount = era_info.map_or(Zero::zero(), |r| r.staked);
-                let write = env.write(&staked_amount.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&staked_amount.encode(), false, None)?;
             }
 
             DappsStakingFunc::StakedAmount => {
@@ -144,11 +128,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 env.charge_weight(base_weight)?;
 
                 let ledger = pallet_dapps_staking::Ledger::<T>::get(&staker);
-                let write = env.write(&ledger.locked.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&ledger.locked.encode(), false, None)?;
             }
 
             DappsStakingFunc::StakedAmountOnContract => {
@@ -162,11 +142,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let staking_info =
                     pallet_dapps_staking::GeneralStakerInfo::<T>::get(&staker, &contract);
                 let staked_amount = staking_info.latest_staked_value();
-                let write = env.write(&staked_amount.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&staked_amount.encode(), false, None)?;
             }
 
             DappsStakingFunc::ReadContractStake => {
@@ -181,11 +157,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     pallet_dapps_staking::Pallet::<T>::contract_stake_info(&contract, current_era)
                         .unwrap_or_default();
                 let total = TryInto::<u128>::try_into(staking_info.total).unwrap_or(0);
-                let write = env.write(&total.encode(), false, None);
-                return match write {
-                    Err(_) => Ok(RetVal::Converging(DSError::FailedToWriteOnBuffer as u32)),
-                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
-                };
+                env.write(&total.encode(), false, None)?;
             }
 
             DappsStakingFunc::BondAndStake => {

--- a/chain-extensions/trait/Cargo.toml
+++ b/chain-extensions/trait/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-extension-trait"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/chain-extensions/trait/src/lib.rs
+++ b/chain-extensions/trait/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-use pallet_contracts::chain_extension::{Environment, Ext, InitState, SysConfig, UncheckedFrom};
+use pallet_contracts::chain_extension::{
+    Environment, Ext, InitState, RetVal, SysConfig, UncheckedFrom,
+};
 use sp_runtime::DispatchError;
 
 /// A Trait used to implement a chain-extension for a pallet
@@ -8,7 +10,10 @@ use sp_runtime::DispatchError;
 ///
 /// T is the Config trait of the pallet
 pub trait ChainExtensionExec<T: SysConfig> {
-    fn execute_func<E>(func_id: u32, env: Environment<E, InitState>) -> Result<(), DispatchError>
+    fn execute_func<E>(
+        func_id: u32,
+        env: Environment<E, InitState>,
+    ) -> Result<RetVal, DispatchError>
     where
         E: Ext<T = T>,
         <E::T as SysConfig>::AccountId:

--- a/chain-extensions/types/dapps-staking/Cargo.toml
+++ b/chain-extensions/types/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapps-staking-chain-extension-types"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/chain-extensions/types/dapps-staking/src/lib.rs
+++ b/chain-extensions/types/dapps-staking/src/lib.rs
@@ -65,8 +65,6 @@ pub enum DSError {
     NominationTransferToSameContract = 26,
     /// Unexpected reward destination value
     RewardDestinationValueOutOfBounds = 27,
-    /// Failed to write result on buffer
-    FailedToWriteOnBuffer = 28,
     /// Unknown error
     UnknownError = 99,
 }

--- a/chain-extensions/types/dapps-staking/src/lib.rs
+++ b/chain-extensions/types/dapps-staking/src/lib.rs
@@ -7,62 +7,68 @@ use sp_runtime::{DispatchError, ModuleError};
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]
 pub enum DSError {
+    /// Success
+    Success = 0,
     /// Disabled
-    Disabled,
+    Disabled = 1,
     /// No change in maintenance mode
-    NoMaintenanceModeChange,
+    NoMaintenanceModeChange = 2,
     /// Upgrade is too heavy, reduce the weight parameter.
-    UpgradeTooHeavy,
+    UpgradeTooHeavy = 3,
     /// Can not stake with zero value.
-    StakingWithNoValue,
+    StakingWithNoValue = 4,
     /// Can not stake with value less than minimum staking value
-    InsufficientValue,
+    InsufficientValue = 5,
     /// Number of stakers per contract exceeded.
-    MaxNumberOfStakersExceeded,
+    MaxNumberOfStakersExceeded = 6,
     /// Targets must be operated contracts
-    NotOperatedContract,
+    NotOperatedContract = 7,
     /// Contract isn't staked.
-    NotStakedContract,
+    NotStakedContract = 8,
     /// Contract isn't unregistered.
-    NotUnregisteredContract,
+    NotUnregisteredContract = 9,
     /// Unclaimed rewards should be claimed before withdrawing stake.
-    UnclaimedRewardsRemaining,
+    UnclaimedRewardsRemaining = 10,
     /// Unstaking a contract with zero value
-    UnstakingWithNoValue,
+    UnstakingWithNoValue = 11,
     /// There are no previously unbonded funds that can be unstaked and withdrawn.
-    NothingToWithdraw,
+    NothingToWithdraw = 12,
     /// The contract is already registered by other account
-    AlreadyRegisteredContract,
+    AlreadyRegisteredContract = 13,
     /// User attempts to register with address which is not contract
-    ContractIsNotValid,
+    ContractIsNotValid = 14,
     /// This account was already used to register contract
-    AlreadyUsedDeveloperAccount,
+    AlreadyUsedDeveloperAccount = 15,
     /// Smart contract not owned by the account id.
-    NotOwnedContract,
+    NotOwnedContract = 16,
     /// Report issue on github if this is ever emitted
-    UnknownEraReward,
+    UnknownEraReward = 17,
     /// Report issue on github if this is ever emitted
-    UnexpectedStakeInfoEra,
+    UnexpectedStakeInfoEra = 18,
     /// Contract has too many unlocking chunks. Withdraw the existing chunks if possible
     /// or wait for current chunks to complete unlocking process to withdraw them.
-    TooManyUnlockingChunks,
+    TooManyUnlockingChunks = 19,
     /// Contract already claimed in this era and reward is distributed
-    AlreadyClaimedInThisEra,
+    AlreadyClaimedInThisEra = 20,
     /// Era parameter is out of bounds
-    EraOutOfBounds,
+    EraOutOfBounds = 21,
     /// Too many active `EraStake` values for (staker, contract) pairing.
     /// Claim existing rewards to fix this problem.
-    TooManyEraStakeValues,
+    TooManyEraStakeValues = 22,
     /// To register a contract, pre-approval is needed for this address
-    RequiredContractPreApproval,
+    RequiredContractPreApproval = 23,
     /// Developer's account is already part of pre-approved list
-    AlreadyPreApprovedDeveloper,
+    AlreadyPreApprovedDeveloper = 24,
     /// Account is not actively staking
-    NotActiveStaker,
+    NotActiveStaker = 25,
     /// Transfering nomination to the same contract
-    NominationTransferToSameContract,
+    NominationTransferToSameContract = 26,
     /// Unexpected reward destination value
-    RewardDestinationValueOutOfBounds,
+    RewardDestinationValueOutOfBounds = 27,
+    /// Failed to write result on buffer
+    FailedToWriteOnBuffer = 28,
+    /// Unknown error
+    UnknownError = 99,
 }
 
 impl TryFrom<DispatchError> for DSError {
@@ -102,7 +108,7 @@ impl TryFrom<DispatchError> for DSError {
             Some("NominationTransferToSameContract") => {
                 Ok(DSError::NominationTransferToSameContract)
             }
-            _ => Err(DispatchError::Other("DappsStakingExtension: Unknown error")),
+            _ => Ok(DSError::UnknownError),
         };
     }
 }


### PR DESCRIPTION
Before the chain extension returned Result<() DispatchError> but it was not possible to decode it on contract side (in a handy way).
The appropriate way is to write to buffer when a value needs to be returned.
When a Result should be returned it should be wrapped in a RetVal and decoded on the contract side. This way no scale decoding error can happen.

**Check list**
- [X] Updated Trait function Return type
- [X] Updated all return statements

