### PR TITLE
Switch polkadot/substrate deps to AstarNetwork

### DIFF
--- a/chain-extensions/impls/dapps-staking/Cargo.toml
+++ b/chain-extensions/impls/dapps-staking/Cargo.toml
@@ -10,17 +10,17 @@ description = "dApps Staking chain extension for WASM contracts"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 log = "0.4.16"
 num-traits = { version = "0.2", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, features = ["unstable-interface"] }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-contracts = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, features = ["unstable-interface"] }
+pallet-contracts-primitives = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-contracts-rpc-runtime-api = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Astar
 chain-extension-trait = { path = "../../trait", default-features = false }

--- a/chain-extensions/trait/Cargo.toml
+++ b/chain-extensions/trait/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Trait definition for chain extension for WASM contracts"
 
 [dependencies]
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, features = ["unstable-interface"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-contracts = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, features = ["unstable-interface"] }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [features]
 default = ["std"]

--- a/chain-extensions/types/dapps-staking/Cargo.toml
+++ b/chain-extensions/types/dapps-staking/Cargo.toml
@@ -10,10 +10,10 @@ description = "Types definitions for dapps-staking chain-extension"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/block-reward/Cargo.toml
+++ b/frame/block-reward/Cargo.toml
@@ -10,18 +10,18 @@ description = "FRAME pallet for managing block reward issuance & distribution"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 scale-info = { version = "2.1", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.27', default-features = false, optional = true }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+frame-benchmarking = { git = 'https://github.com/AstarNetwork/substrate.git', branch = 'polkadot-v0.9.27', default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
 serde = { version = "1.0.136", optional = true }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
 
 [features]
 default = ["std"]

--- a/frame/collator-selection/Cargo.toml
+++ b/frame/collator-selection/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://substrate.io"
 license = "Apache-2.0"
 name = "pallet-collator-selection"
 readme = "README.md"
-repository = "https://github.com/paritytech/cumulus/"
+repository = "https://github.com/AstarNetwork/cumulus/"
 version = "3.3.1"
 
 [package.metadata.docs.rs]
@@ -19,25 +19,25 @@ rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.132", default-features = false }
 
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+frame-support = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+frame-system = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-authorship = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-session = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-staking = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-std = { default-features = false, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [dev-dependencies]
-pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+pallet-aura = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-consensus-aura = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-tracing = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/frame/custom-signatures/Cargo.toml
+++ b/frame/custom-signatures/Cargo.toml
@@ -10,21 +10,21 @@ description = "FRAME pallet for user defined extrinsic signatures"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.140", features = ["derive"], optional = true }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.4"
 libsecp256k1 = "0.7.0"
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-keyring = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -10,22 +10,22 @@ license = "PolyForm-Noncommercial-1.0.0"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+pallet-session = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.106", features = ["derive"], optional = true }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-arithmetic = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-staking = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.27', default-features = false, optional = true }
+frame-benchmarking = { git = 'https://github.com/AstarNetwork/substrate.git', branch = 'polkadot-v0.9.27', default-features = false, optional = true }
 
 [features]
 default = ["std"]

--- a/frame/pallet-xcm/Cargo.toml
+++ b/frame/pallet-xcm/Cargo.toml
@@ -10,21 +10,21 @@ log = { version = "0.4.16", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.140", optional = true, features = ["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", default-features = false, branch = "polkadot-v0.9.27" }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
+xcm = { git = "https://github.com/AstarNetwork/polkadot", default-features = false, branch = "release-v0.9.27" }
+xcm-executor = { git = "https://github.com/AstarNetwork/polkadot", default-features = false, branch = "release-v0.9.27" }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27" }
-polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+polkadot-parachain = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27" }
+polkadot-runtime-parachains = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27" }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+xcm-builder = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/frame/vesting/Cargo.toml
+++ b/frame/vesting/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"
-repository = "https://github.com/paritytech/substrate/"
+repository = "https://github.com/AstarNetwork/substrate/"
 description = "FRAME pallet for manage vesting"
 readme = "README.md"
 
@@ -16,18 +16,18 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
 	"derive",
 ] }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-benchmarking = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false, optional = true }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 log = { version = "0.4.0", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 [features]
 default = ["std"]

--- a/frame/xc-asset-config/Cargo.toml
+++ b/frame/xc-asset-config/Cargo.toml
@@ -9,24 +9,24 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1.0.140", optional = true }
 
 # Substrate
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Polkadot
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", optional = true, default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -14,14 +14,14 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-assets = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
@@ -35,9 +35,9 @@ sha3 = "0.10.1"
 precompile-utils = { path = "../utils", features = ["testing"] }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", features = ["max-encoded-len"] }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -10,15 +10,15 @@ description = "dApps Staking EVM precompiles"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 log = "0.4.16"
 num_enum = { version = "0.5.3", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Astar
 pallet-dapps-staking = { path = "../../frame/dapps-staking", default-features = false }
@@ -29,13 +29,13 @@ pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polka
 
 [dev-dependencies]
 derive_more = "0.99"
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 precompile-utils = { path = "../utils", features = ["testing"] }
 serde = "1.0.140"
 sha3 = "0.10.1"
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/precompiles/sr25519/Cargo.toml
+++ b/precompiles/sr25519/Cargo.toml
@@ -12,9 +12,9 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
@@ -28,11 +28,11 @@ serde = "1.0.140"
 
 precompile-utils = { path = "../utils", features = ["testing"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/precompiles/substrate-ecdsa/Cargo.toml
+++ b/precompiles/substrate-ecdsa/Cargo.toml
@@ -12,9 +12,9 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
@@ -28,11 +28,11 @@ serde = "1.0.140"
 
 precompile-utils = { path = "../utils", features = ["testing"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -16,12 +16,12 @@ precompile-utils-macro = { path = "macro" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Frontier
 evm = { git = "https://github.com/rust-blockchain/evm", branch = "master", default-features = false, features = ["with-codec"] }
@@ -29,7 +29,7 @@ fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
 
 # Polkadot / XCM
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.1"

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -14,20 +14,20 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-system = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+pallet-assets = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-core = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-io = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.27", default-features = false }
 
 # Polkadot
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm-executor = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -37,10 +37,10 @@ serde = "1.0.140"
 
 precompile-utils = { path = "../utils", features = ["testing"] }
 
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27" }
+pallet-balances = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+pallet-timestamp = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27" }
+xcm-builder = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27" }
 
 [features]
 default = ["std"]

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2021"
 log = { version = "0.4", default-features = false }
 
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", default-features = false }
+frame-support = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-runtime = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
+sp-std = { git = "https://github.com/AstarNetwork/substrate", branch = "polkadot-v0.9.27", default-features = false }
 
 # XCM dependencies
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm-builder = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
+xcm-executor = { git = "https://github.com/AstarNetwork/polkadot", branch = "release-v0.9.27", default-features = false }
 
 # Astar pallets
 pallet-xc-asset-config = { path = "../../frame/xc-asset-config", default-features = false }


### PR DESCRIPTION
**Pull Request Summary**

This PR temporary point all polkadot/cumulus/substrate dependencies into AstarNetwork clones.

I noticed that we use different versions of substrate/polkadot/cumulus in one project, it could be a cause of unpredictable behaviour, better to point it all to one repo. 

**Check list**
- [ ] added unit tests
- [ ] updated documentation
