### PR TITLE
Set contract address to be the caller

### DIFF
--- a/chain-extensions/impls/dapps-staking/Cargo.toml
+++ b/chain-extensions/impls/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapps-staking-chain-extension"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -7,7 +7,8 @@ use sp_runtime::{
 use chain_extension_trait::ChainExtensionExec;
 use codec::{Decode, Encode};
 use dapps_staking_chain_extension_types::{
-    Contract, DSError, DappsStakingAccountInput, DappsStakingEraInput, DappsStakingValueInput,
+    Contract, DSError, DappsStakingAccountInput, DappsStakingEraInput, DappsStakingNominationInput,
+    DappsStakingValueInput,
 };
 use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
@@ -35,6 +36,7 @@ enum DappsStakingFunc {
     ClaimStaker,
     ClaimDapp,
     SetRewardDestination,
+    NominationTransfer,
 }
 
 impl TryFrom<u32> for DappsStakingFunc {
@@ -55,6 +57,7 @@ impl TryFrom<u32> for DappsStakingFunc {
             11 => Ok(DappsStakingFunc::ClaimStaker),
             12 => Ok(DappsStakingFunc::ClaimDapp),
             13 => Ok(DappsStakingFunc::SetRewardDestination),
+            14 => Ok(DappsStakingFunc::NominationTransfer),
             _ => Err(DispatchError::Other(
                 "DappsStakingExtension: Unimplemented func_id",
             )),
@@ -295,6 +298,32 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let call_result = pallet_dapps_staking::Pallet::<T>::set_reward_destination(
                     RawOrigin::Signed(caller).into(),
                     reward_destination,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = DSError::try_from(e.error)?;
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(DSError::Success as u32)),
+                };
+            }
+
+            DappsStakingFunc::NominationTransfer => {
+                let args: DappsStakingNominationInput<BalanceOf<T>> = env.read_as()?;
+                let origin_smart_contract = Self::decode_smart_contract(args.origin_contract)?;
+                let target_smart_contract = Self::decode_smart_contract(args.target_contract)?;
+                let value: BalanceOf<T> = args.value;
+
+                let base_weight =
+                    <T as pallet_dapps_staking::Config>::WeightInfo::nomination_transfer();
+                env.charge_weight(base_weight)?;
+
+                let caller = env.ext().caller().clone();
+                let call_result = pallet_dapps_staking::Pallet::<T>::nomination_transfer(
+                    RawOrigin::Signed(caller).into(),
+                    origin_smart_contract,
+                    value,
+                    target_smart_contract,
                 );
                 return match call_result {
                     Err(e) => {

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -10,10 +10,7 @@ use dapps_staking_chain_extension_types::{
     Contract, DSError, DappsStakingAccountInput, DappsStakingEraInput, DappsStakingNominationInput,
     DappsStakingValueInput,
 };
-use frame_support::{
-    log,
-    traits::{Currency, Get},
-};
+use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
 use pallet_contracts::chain_extension::{
     Environment, Ext, InitState, RetVal, SysConfig, UncheckedFrom,
@@ -167,7 +164,6 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let args: DappsStakingValueInput<BalanceOf<T>> = env.read_as()?;
                 let contract = Self::decode_smart_contract(args.contract)?;
                 let value: BalanceOf<T> = args.value;
-                log::debug!(target: "runtime", "BondAndStake value {:?}", value);
 
                 let base_weight = <T as pallet_dapps_staking::Config>::WeightInfo::bond_and_stake();
                 env.charge_weight(base_weight)?;

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -10,7 +10,10 @@ use dapps_staking_chain_extension_types::{
     Contract, DSError, DappsStakingAccountInput, DappsStakingEraInput, DappsStakingNominationInput,
     DappsStakingValueInput,
 };
-use frame_support::traits::{Currency, Get};
+use frame_support::{
+    log,
+    traits::{Currency, Get},
+};
 use frame_system::RawOrigin;
 use pallet_contracts::chain_extension::{
     Environment, Ext, InitState, RetVal, SysConfig, UncheckedFrom,
@@ -164,6 +167,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let args: DappsStakingValueInput<BalanceOf<T>> = env.read_as()?;
                 let contract = Self::decode_smart_contract(args.contract)?;
                 let value: BalanceOf<T> = args.value;
+                log::debug!(target: "runtime", "BondAndStake value {:?}", value);
 
                 let base_weight = <T as pallet_dapps_staking::Config>::WeightInfo::bond_and_stake();
                 env.charge_weight(base_weight)?;
@@ -192,7 +196,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     <T as pallet_dapps_staking::Config>::WeightInfo::unbond_and_unstake();
                 env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::unbond_and_unstake(
                     RawOrigin::Signed(caller).into(),
                     contract,
@@ -208,7 +212,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
             }
 
             DappsStakingFunc::WithdrawUnbonded => {
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
 
                 let base_weight =
                     <T as pallet_dapps_staking::Config>::WeightInfo::withdraw_unbonded();
@@ -234,7 +238,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     .max(T::WeightInfo::claim_staker_without_restake());
                 let charged_weight = env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::claim_staker(
                     RawOrigin::Signed(caller).into(),
                     contract,
@@ -262,7 +266,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let base_weight = <T as pallet_dapps_staking::Config>::WeightInfo::claim_dapp();
                 env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::claim_dapp(
                     RawOrigin::Signed(caller).into(),
                     contract,
@@ -294,7 +298,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     return Ok(RetVal::Converging(error as u32));
                 };
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::set_reward_destination(
                     RawOrigin::Signed(caller).into(),
                     reward_destination,
@@ -318,7 +322,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     <T as pallet_dapps_staking::Config>::WeightInfo::nomination_transfer();
                 env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::nomination_transfer(
                     RawOrigin::Signed(caller).into(),
                     origin_smart_contract,

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -318,7 +318,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     <T as pallet_dapps_staking::Config>::WeightInfo::nomination_transfer();
                 env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::nomination_transfer(
                     RawOrigin::Signed(caller).into(),
                     origin_smart_contract,

--- a/chain-extensions/impls/dapps-staking/src/lib.rs
+++ b/chain-extensions/impls/dapps-staking/src/lib.rs
@@ -168,7 +168,7 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                 let base_weight = <T as pallet_dapps_staking::Config>::WeightInfo::bond_and_stake();
                 env.charge_weight(base_weight)?;
 
-                let caller = env.ext().caller().clone();
+                let caller = env.ext().address().clone();
                 let call_result = pallet_dapps_staking::Pallet::<T>::bond_and_stake(
                     RawOrigin::Signed(caller).into(),
                     contract,


### PR DESCRIPTION
**Pull Request Summary**
In the dapps-staking chain-extension use contract to be the origin for the calls


**Check list**
- [x] chain-extension e2e test are updated and working. See chain-extension-contracts test [PR#1](https://github.com/AstarNetwork/chain-extension-contracts/pull/1)
- [x] removed support for nomination_transfer()
