### PR TITLE
Fix evm duplicated dependency

### DIFF
--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 version = "0.4.3"
 
 [dependencies]
+# There's a problem with --all-features when this is moved under dev-deps
+evm = { git = "https://github.com/rust-blockchain/evm", rev = "01bcbd2205a212c34451d3b4fabc962793b057d3", optional = true }
 impl-trait-for-tuples = "0.2.2"
 log = "0.4.16"
 num_enum = { version = "0.5.3", default-features = false }
@@ -32,8 +34,6 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 
 [dev-dependencies]
 hex-literal = "0.3.1"
-# If this is moved from dev-deps, ensure the same version as frontier is used to avoid duplicated deps
-evm = { git = "https://github.com/rust-blockchain/evm", rev = "01bcbd2205a212c34451d3b4fabc962793b057d3", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -3,7 +3,7 @@ name = "precompile-utils"
 authors = ["StakeTechnologies", "PureStake"]
 description = "Utils to write EVM precompiles."
 edition = "2021"
-version = "0.4.2"
+version = "0.4.3"
 
 [dependencies]
 impl-trait-for-tuples = "0.2.2"
@@ -24,7 +24,6 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 
 # Frontier
-evm = { git = "https://github.com/rust-blockchain/evm", branch = "master", default-features = false, features = ["with-codec"] }
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.28", default-features = false }
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.28", default-features = false }
 
@@ -33,6 +32,8 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 
 [dev-dependencies]
 hex-literal = "0.3.1"
+# If this is moved from dev-deps, ensure the same version as frontier is used to avoid duplicated deps
+evm = { git = "https://github.com/rust-blockchain/evm", rev = "01bcbd2205a212c34451d3b4fabc962793b057d3", default-features = false, features = ["with-codec"] }
 
 [features]
 default = ["std"]

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -297,68 +297,6 @@ pub fn log_costs(topics: usize, data_len: usize) -> EvmResult<u64> {
         })
 }
 
-// Compute the cost of doing a subcall.
-// Some parameters cannot be known in advance, so we estimate the worst possible cost.
-pub fn call_cost(value: U256, config: &evm::Config) -> u64 {
-    // Copied from EVM code since not public.
-    pub const G_CALLVALUE: u64 = 9000;
-    pub const G_NEWACCOUNT: u64 = 25000;
-
-    fn address_access_cost(is_cold: bool, regular_value: u64, config: &evm::Config) -> u64 {
-        if config.increase_state_access_gas {
-            if is_cold {
-                config.gas_account_access_cold
-            } else {
-                config.gas_storage_read_warm
-            }
-        } else {
-            regular_value
-        }
-    }
-
-    fn xfer_cost(is_call_or_callcode: bool, transfers_value: bool) -> u64 {
-        if is_call_or_callcode && transfers_value {
-            G_CALLVALUE
-        } else {
-            0
-        }
-    }
-
-    fn new_cost(
-        is_call_or_staticcall: bool,
-        new_account: bool,
-        transfers_value: bool,
-        config: &evm::Config,
-    ) -> u64 {
-        let eip161 = !config.empty_considered_exists;
-        if is_call_or_staticcall {
-            if eip161 {
-                if transfers_value && new_account {
-                    G_NEWACCOUNT
-                } else {
-                    0
-                }
-            } else if new_account {
-                G_NEWACCOUNT
-            } else {
-                0
-            }
-        } else {
-            0
-        }
-    }
-
-    let transfers_value = value != U256::default();
-    let is_cold = true;
-    let is_call_or_callcode = true;
-    let is_call_or_staticcall = true;
-    let new_account = true;
-
-    address_access_cost(is_cold, config.gas_call, config)
-        + xfer_cost(is_call_or_callcode, transfers_value)
-        + new_cost(is_call_or_staticcall, new_account, transfers_value, config)
-}
-
 impl<T: PrecompileHandle> PrecompileHandleExt for T {
     #[must_use]
     /// Record cost of a log manualy.

--- a/precompiles/utils/src/testing.rs
+++ b/precompiles/utils/src/testing.rs
@@ -147,10 +147,7 @@ impl PrecompileHandle for MockHandle {
         context: &Context,
     ) -> (ExitReason, Vec<u8>) {
         if self
-            .record_cost(super::call_cost(
-                context.apparent_value,
-                &evm::Config::london(),
-            ))
+            .record_cost(call_cost(context.apparent_value, &evm::Config::london()))
             .is_err()
         {
             return (ExitReason::Error(ExitError::OutOfGas), vec![]);

--- a/precompiles/utils/src/testing.rs
+++ b/precompiles/utils/src/testing.rs
@@ -72,6 +72,68 @@ impl MockHandle {
     }
 }
 
+// Compute the cost of doing a subcall.
+// Some parameters cannot be known in advance, so we estimate the worst possible cost.
+pub fn call_cost(value: U256, config: &evm::Config) -> u64 {
+    // Copied from EVM code since not public.
+    pub const G_CALLVALUE: u64 = 9000;
+    pub const G_NEWACCOUNT: u64 = 25000;
+
+    fn address_access_cost(is_cold: bool, regular_value: u64, config: &evm::Config) -> u64 {
+        if config.increase_state_access_gas {
+            if is_cold {
+                config.gas_account_access_cold
+            } else {
+                config.gas_storage_read_warm
+            }
+        } else {
+            regular_value
+        }
+    }
+
+    fn xfer_cost(is_call_or_callcode: bool, transfers_value: bool) -> u64 {
+        if is_call_or_callcode && transfers_value {
+            G_CALLVALUE
+        } else {
+            0
+        }
+    }
+
+    fn new_cost(
+        is_call_or_staticcall: bool,
+        new_account: bool,
+        transfers_value: bool,
+        config: &evm::Config,
+    ) -> u64 {
+        let eip161 = !config.empty_considered_exists;
+        if is_call_or_staticcall {
+            if eip161 {
+                if transfers_value && new_account {
+                    G_NEWACCOUNT
+                } else {
+                    0
+                }
+            } else if new_account {
+                G_NEWACCOUNT
+            } else {
+                0
+            }
+        } else {
+            0
+        }
+    }
+
+    let transfers_value = value != U256::default();
+    let is_cold = true;
+    let is_call_or_callcode = true;
+    let is_call_or_staticcall = true;
+    let new_account = true;
+
+    address_access_cost(is_cold, config.gas_call, config)
+        + xfer_cost(is_call_or_callcode, transfers_value)
+        + new_cost(is_call_or_staticcall, new_account, transfers_value, config)
+}
+
 impl PrecompileHandle for MockHandle {
     /// Perform subcall in provided context.
     /// Precompile specifies in which context the subcall is executed.


### PR DESCRIPTION
**Pull Request Summary**

Makes `evm` dependency in `precompile-utils` optional.

Moved the only function that relies on that crate to _testing.rs_ since it's only used there.
This should help avoid using different `evm` versions in the future for production code.
