### PR TITLE
XVM gas handling prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ members = [
 	"precompiles/xcm",
 	"precompiles/xvm",
 
-	"contracts/*",
+	# "contracts/*",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,7 @@ members = [
 	"precompiles/xcm",
 	"precompiles/xvm",
 
+	# Current build fails due to error associated with incorrect nightly usage
+	# but we use one from polkadot release so we probably shouldn't change it yet.
 	# "contracts/*",
 ]

--- a/chain-extensions/impls/xvm/src/lib.rs
+++ b/chain-extensions/impls/xvm/src/lib.rs
@@ -53,11 +53,7 @@ where
 
                 let caller = env.ext().caller().clone();
 
-                let XvmCallArgs {
-                    vm_id,
-                    to,
-                    input,
-                } = env.read_as_unbounded(env.in_len())?;
+                let XvmCallArgs { vm_id, to, input } = env.read_as_unbounded(env.in_len())?;
 
                 let _origin_address = env.ext().address().clone();
                 let _value = env.ext().value_transferred();

--- a/chain-extensions/impls/xvm/src/lib.rs
+++ b/chain-extensions/impls/xvm/src/lib.rs
@@ -49,7 +49,7 @@ where
             XvmFuncId::XvmCall => {
                 // TODO: correct weight calculation directly from pallet!
                 let weight = 1_000_000_000;
-                env.charge_weight(weight)?;
+                let charged_weight = env.charge_weight(weight)?;
 
                 // Prepare parameters
                 let caller = env.ext().caller().clone();
@@ -80,9 +80,11 @@ where
                 // TODO: We need to know how much of gas was spent in the other call and update the gas meter!
                 // let consumed_xvm_weight = ...;
                 // env.charge_weight(consumed_xvm_weight)?;
+                // adjust_weight
 
                 return match call_result {
                     Err(e) => {
+                        e.post_info.actual_weight;
                         let mapped_error = XvmExecutionResult::try_from(e.error)?;
                         Ok(RetVal::Converging(mapped_error as u32))
                     }

--- a/chain-extensions/impls/xvm/src/lib.rs
+++ b/chain-extensions/impls/xvm/src/lib.rs
@@ -60,7 +60,6 @@ where
                 let xvm_context = XvmContext {
                     id: vm_id,
                     max_weight: remaining_weight,
-                    call_depth: 1,
                     env: None,
                 };
 

--- a/chain-extensions/impls/xvm/src/lib.rs
+++ b/chain-extensions/impls/xvm/src/lib.rs
@@ -64,6 +64,7 @@ where
                 let xvm_context = XvmContext {
                     id: vm_id,
                     max_weight: remaining_weight,
+                    call_depth: 1,
                     env: None,
                 };
 

--- a/chain-extensions/types/xvm/Cargo.toml
+++ b/chain-extensions/types/xvm/Cargo.toml
@@ -10,19 +10,15 @@ description = "Types definitions for contracts using xvm chain-extension."
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
-scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 ink_prelude = { version = "3", default-features = false }
+scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"codec/std",
-	"frame-support/std",
 	"scale-info/std",
-	"sp-core/std",
 	"sp-runtime/std",
 	"ink_prelude/std",
 ]

--- a/chain-extensions/types/xvm/Cargo.toml
+++ b/chain-extensions/types/xvm/Cargo.toml
@@ -14,7 +14,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+ink_prelude = { version = "3", default-features = false }
 
 [features]
 default = ["std"]
@@ -24,5 +24,5 @@ std = [
 	"scale-info/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"sp-std/std",
+	"ink_prelude/std",
 ]

--- a/chain-extensions/types/xvm/src/lib.rs
+++ b/chain-extensions/types/xvm/src/lib.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use codec::{Decode, Encode};
+use ink_prelude::vec::Vec;
 use sp_runtime::{DispatchError, ModuleError};
-use sp_std::vec::Vec; // TODO use ink_prelude::vec::Vec; ?
 
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]

--- a/contracts/xvm/Cargo.toml
+++ b/contracts/xvm/Cargo.toml
@@ -38,5 +38,6 @@ std = [
 	"ink_primitives/std",
 	"scale/std",
 	"scale-info/std",
+	"xvm-chain-extension-types/std",
 ]
 ink-as-dependency = []

--- a/contracts/xvm/Cargo.toml
+++ b/contracts/xvm/Cargo.toml
@@ -9,20 +9,24 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Chain extension for X-VM calls"
 
 [dependencies]
-ink_env = { version = "3", default-features = false }
-ink_lang = { version = "3", default-features = false }
-ink_metadata = { version = "3", default-features = false, features = ["derive"], optional = true }
-ink_prelude = { version = "3", default-features = false }
-ink_primitives = { version = "3", default-features = false }
-ink_storage = { version = "3", default-features = false }
+ink_env = { version = "3.3", default-features = false }
+ink_lang = { version = "3.3", default-features = false }
+ink_metadata = { version = "3.3", default-features = false, features = [
+	"derive",
+], optional = true }
+ink_prelude = { version = "3.3", default-features = false }
+ink_primitives = { version = "3.3", default-features = false }
+ink_storage = { version = "3.3", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
-
-xvm-chain-extension-types = { path = "../../chain-extensions/types/xvm", default-features = false }
+scale = { package = "parity-scale-codec", version = "3", default-features = false, features = [
+	"derive",
+] }
+scale-info = { version = "2", default-features = false, features = [
+	"derive",
+], optional = true }
 
 [lib]
-name = "xvm_chain_extension_contract"
+name = "xvm_example"
 path = "src/lib.rs"
 crate-type = [
 	# Used for normal contract Wasm blobs.
@@ -36,8 +40,8 @@ std = [
 	"ink_env/std",
 	"ink_storage/std",
 	"ink_primitives/std",
+	"ink_prelude/std",
 	"scale/std",
 	"scale-info/std",
-	"xvm-chain-extension-types/std",
 ]
 ink-as-dependency = []

--- a/contracts/xvm/src/lib.rs
+++ b/contracts/xvm/src/lib.rs
@@ -1,8 +1,22 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use ink_env::{DefaultEnvironment, Environment};
 use ink_lang as ink;
-use xvm_chain_extension_types::XvmCallArgs;
+
+use ink_env::{DefaultEnvironment, Environment};
+use ink_prelude::vec::Vec;
+
+#[derive(Clone, PartialEq, Eq, scale::Encode, scale::Decode, Debug)]
+pub struct XvmCallArgs {
+    /// virtual machine identifier
+    pub vm_id: u8,
+    /// Call destination (e.g. address)
+    pub to: Vec<u8>,
+    /// Encoded call params
+    pub input: Vec<u8>,
+}
+
+pub const FRONTIER_VM_ID: u8 = 0x0F;
+pub const PARITY_WASM_VM_ID: u8 = 0x1F;
 
 #[ink::chain_extension]
 pub trait XvmChainExtension {
@@ -53,7 +67,7 @@ impl Environment for CustomEnvironment {
 ///
 /// This will give us access to the chain extension that we've defined.
 #[ink::contract(env = crate::CustomEnvironment)]
-mod xvm_chain_extension_contract {
+mod xvm_example {
 
     use super::*;
     use scale::Encode;
@@ -72,8 +86,8 @@ mod xvm_chain_extension_contract {
             self.env()
                 .extension()
                 .xvm_call(XvmCallArgs {
-                    vm_id: xvm_chain_extension_types::FRONTIER_VM_ID,
-                    to: address.encode(), // TODO: is this correct?
+                    vm_id: FRONTIER_VM_ID,
+                    to: address.encode(),
                     input: Default::default(),
                 })
                 .map_err(|_| ExtensionError::XvmCallFailed)?;

--- a/contracts/xvm/src/lib.rs
+++ b/contracts/xvm/src/lib.rs
@@ -75,7 +75,6 @@ mod xvm_chain_extension_contract {
                     vm_id: xvm_chain_extension_types::FRONTIER_VM_ID,
                     to: address.encode(), // TODO: is this correct?
                     input: Default::default(),
-                    metadata: Default::default(),
                 })
                 .map_err(|_| ExtensionError::XvmCallFailed)?;
 

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -20,17 +20,11 @@ where
         I::get()
     }
 
-    fn xvm_call(
-        context: XvmContext<VmId>,
-        from: T::AccountId,
-        to: Vec<u8>,
-        input: Vec<u8>,
-        metadata: Vec<u8>,
-    ) -> XvmResult {
+    fn xvm_call(context: XvmContext, from: T::AccountId, to: Vec<u8>, input: Vec<u8>) -> XvmResult {
         log::trace!(
             target: "xvm::EVM::xvm_call",
-            "Start EVM XVM: {:?}, {:?}, {:?}, {:?}",
-            from, to, input, metadata,
+            "Start EVM XVM: {:?}, {:?}, {:?}",
+            from, to, input,
         );
         let value = U256::from(0u64);
         let max_fee_per_gas = U256::from(3450898690u64);

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -24,7 +24,8 @@ where
         from: T::AccountId,
         to: Vec<u8>,
         input: Vec<u8>,
-    ) -> Result<Vec<u8>, Vec<u8>> {
+        metadata: Vec<u8>,
+    ) -> XvmResult {
         log::trace!(
             target: "xvm::EVM::xvm_call",
             "Start EVM XVM: {:?}, {:?}, {:?}, {:?}",
@@ -33,8 +34,10 @@ where
         let value = U256::from(0u64);
         let max_fee_per_gas = U256::from(3450898690u64);
         let gas_limit = 4000000u64;
-        let evm_to: H160 = Decode::decode(&mut to.as_ref())
-            .map_err(|_| b"`to` argument decode failure".to_vec())?;
+        let evm_to = Decode::decode(&mut to.as_ref()).map_err(|_| XvmCallError {
+            error: XvmError::EncodingFailure,
+            consumed_weight: PLACEHOLDER_WEIGHT,
+        })?;
 
         let res = pallet_evm::Pallet::<T>::call(
             frame_support::dispatch::RawOrigin::Root.into(),
@@ -47,14 +50,22 @@ where
             None,
             None,
             Vec::new(),
-        );
+        )
+        .map_err(|_| XvmCallError {
+            error: XvmError::ExecutionError(Vec::default()), // TODO: make error mapping make more sense
+            consumed_weight: PLACEHOLDER_WEIGHT,
+        })?;
 
         log::trace!(
             target: "xvm::EVM::xvm_call",
             "EVM XVM call result: {:?}", res
         );
 
-        // TODO: return result or error if call failure
-        Ok(Default::default())
+        // TODO: return error if call failure
+        // TODO: return value in case of constant / view call
+        Ok(XvmCallOk {
+            output: Default::default(), // TODO: vec should be filled with data in case of query? Should be generic probably.
+            consumed_weight: res.actual_weight.unwrap_or(PLACEHOLDER_WEIGHT), // TODO: this should be max static weight if `None`
+        })
     }
 }

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -59,7 +59,6 @@ where
             "EVM XVM call result: {:?}", res
         );
 
-        // TODO: return value in case of constant / view call
         Ok(XvmCallOk {
             output: Default::default(), // TODO: Fill output vec with response from the call
             consumed_weight: res.actual_weight.unwrap_or(context.max_weight),

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -33,7 +33,7 @@ where
         );
         let value = U256::from(0u64);
         let max_fee_per_gas = U256::from(3450898690u64);
-        let gas_limit = 4000000u64;
+        let gas_limit = 15_000_000_u64;
         let evm_to = Decode::decode(&mut to.as_ref()).map_err(|_| XvmCallError {
             error: XvmError::EncodingFailure,
             consumed_weight: PLACEHOLDER_WEIGHT,
@@ -53,7 +53,7 @@ where
         )
         .map_err(|_| XvmCallError {
             error: XvmError::ExecutionError(Vec::default()), // TODO: make error mapping make more sense
-            consumed_weight: PLACEHOLDER_WEIGHT,
+            consumed_weight: PLACEHOLDER_WEIGHT,             // TODO: get correct weight?
         })?;
 
         log::trace!(

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -102,12 +102,7 @@ pub trait SyncVM<AccountId> {
     /// Make a call to VM contract and return result or error.
     ///
     ///
-    fn xvm_call(
-        context: XvmContext,
-        from: AccountId,
-        to: Vec<u8>,
-        input: Vec<u8>,
-    ) -> XvmResult;
+    fn xvm_call(context: XvmContext, from: AccountId, to: Vec<u8>, input: Vec<u8>) -> XvmResult;
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]
@@ -116,12 +111,7 @@ impl<AccountId: Member> SyncVM<AccountId> for Tuple {
         Default::default()
     }
 
-    fn xvm_call(
-        context: XvmContext,
-        from: AccountId,
-        to: Vec<u8>,
-        input: Vec<u8>,
-    ) -> XvmResult {
+    fn xvm_call(context: XvmContext, from: AccountId, to: Vec<u8>, input: Vec<u8>) -> XvmResult {
         for_tuples!( #(
             if Tuple::id() == context.id {
                 log::trace!(
@@ -150,15 +140,10 @@ pub trait AsyncVM<AccountId> {
     fn id() -> VmId;
 
     /// Send a message.
-    fn xvm_send(
-        context: XvmContext<VmId>,
-        from: AccountId,
-        to: Vec<u8>,
-        message: Vec<u8>,
-    ) -> XvmResult;
+    fn xvm_send(context: XvmContext, from: AccountId, to: Vec<u8>, message: Vec<u8>) -> XvmResult;
 
     /// Query for incoming messages.
-    fn xvm_query(context: XvmContext<VmId>, inbox: AccountId) -> XvmResult;
+    fn xvm_query(context: XvmContext, inbox: AccountId) -> XvmResult;
 }
 
 #[impl_trait_for_tuples::impl_for_tuples(30)]
@@ -167,12 +152,7 @@ impl<AccountId: Member> AsyncVM<AccountId> for Tuple {
         Default::default()
     }
 
-    fn xvm_send(
-        context: XvmContext,
-        from: AccountId,
-        to: Vec<u8>,
-        message: Vec<u8>,
-    ) -> XvmResult {
+    fn xvm_send(context: XvmContext, from: AccountId, to: Vec<u8>, message: Vec<u8>) -> XvmResult {
         for_tuples!( #(
             if Tuple::id() == context.id {
                 log::trace!(
@@ -194,7 +174,7 @@ impl<AccountId: Member> AsyncVM<AccountId> for Tuple {
         })
     }
 
-    fn xvm_query(context: XvmContext<VmId>, inbox: AccountId) -> XvmResult {
+    fn xvm_query(context: XvmContext, inbox: AccountId) -> XvmResult {
         for_tuples!( #(
             if Tuple::id() == context.id {
                 log::trace!(

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -46,7 +46,7 @@ pub enum XvmError {
     ExecutionError(Vec<u8>),
 }
 
-// TODO: Currently our precompile/chain-extension calls rely on direcy `Call` usage of XVM pallet.
+// TODO: Currently our precompile/chain-extension calls rely on direct `Call` usage of XVM pallet.
 // This is perfectly fine when we're just calling a function in other VM and are interested whether the call was
 // successful or not.
 //
@@ -70,6 +70,7 @@ pub struct XvmCallError {
     consumed_weight: u64,
 }
 
+/// Result for executing X-VM calls
 pub type XvmResult = Result<XvmCallOk, XvmCallError>;
 
 pub fn consumed_weight(result: &XvmResult) -> Weight {

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -30,13 +30,12 @@ pub mod evm;
 pub mod wasm;
 
 /// Unique VM identifier.
-type VmId = u8;
+pub type VmId = u8;
 
 // TODO: remove later after solution is properly benchmarked
 // Just a arbitrary weight constant to avoid having ZERO weight in some parts of execution
 pub const PLACEHOLDER_WEIGHT: u64 = 1_000_000;
 
-/// TODO: This isn't an exhaustive list, only a few are listed
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
 pub enum XvmError {
     VmNotRecognized,
@@ -44,6 +43,7 @@ pub enum XvmError {
     ContextConversionFailed,
     OutOfGas,
     ExecutionError(Vec<u8>),
+    // extend this list as part of improved error handling
 }
 
 // TODO: Currently our precompile/chain-extension calls rely on direct `Call` usage of XVM pallet.
@@ -53,6 +53,7 @@ pub enum XvmError {
 // Problem arises IF we want to get back arbitrary read value from the other VM - `DispatchResultWithPostInfo` isn't enough for this.
 // We need to receive back a concrete value back from the other VM.
 
+/// Denotes a successful XVM call execution
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
 pub struct XvmCallOk {
     /// Output of XVM call. E.g. if call was a query, this will contain query response.
@@ -61,6 +62,7 @@ pub struct XvmCallOk {
     consumed_weight: u64,
 }
 
+/// Denotes an successful XVM call execution
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
 pub struct XvmCallError {
     /// Result of XVM call
@@ -87,8 +89,6 @@ pub struct XvmContext {
     pub id: VmId,
     /// Max allowed weight for the call
     pub max_weight: Weight,
-    /// XVM call depth: TODO: ensure that we cannot nest it too deeply - at least initially.
-    pub call_depth: u8,
     /// Encoded VM execution environment.
     pub env: Option<Vec<u8>>,
 }

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -31,6 +31,9 @@ pub mod wasm;
 
 /// Unique VM identifier.
 type VmId = u8;
+
+// TODO: remove later after solution is properly benchmarked
+// Just a arbitrary weight constant to avoid having ZERO weight in some parts of execution
 pub const PLACEHOLDER_WEIGHT: u64 = 1_000_000;
 
 /// TODO: This isn't an exhaustive list, only a few are listed

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -81,7 +81,7 @@ pub fn consumed_weight(result: &XvmResult) -> Weight {
 }
 
 /// XVM context consist of unique ID and optional execution arguments.
-#[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
+#[derive(Default, PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
 pub struct XvmContext {
     /// Identifier (should be unique for each VM in tuple).
     pub id: VmId,

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -83,6 +83,8 @@ pub struct XvmContext {
     pub id: VmId,
     /// Max allowed weight for the call
     pub max_weight: Weight,
+    /// XVM call depth: TODO: ensure that we cannot nest it too deeply - at least initially.
+    pub call_depth: u8,
     /// Encoded VM execution environment.
     pub env: Option<Vec<u8>>,
 }

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -89,10 +89,7 @@ pub mod pallet {
         }
 
         #[pallet::weight(100_000)]
-        pub fn xvm_query(
-            origin: OriginFor<T>,
-            context: XvmContext,
-        ) -> DispatchResultWithPostInfo {
+        pub fn xvm_query(origin: OriginFor<T>, context: XvmContext) -> DispatchResultWithPostInfo {
             let inbox = ensure_signed(origin)?;
             let _result = T::AsyncVM::xvm_query(context, inbox);
 

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -57,6 +57,11 @@ pub mod pallet {
             input: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
             let from = ensure_signed(origin)?;
+
+            // Executing XVM call logic itself will consume some weight so that should be subtracted from the max allowed weight of XCM call
+            let mut context = context;
+            context.max_weight = context.max_weight - PLACEHOLDER_WEIGHT;
+
             let result = T::SyncVM::xvm_call(context, from, to, input);
 
             Self::deposit_event(Event::<T>::XvmCall {

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -46,7 +46,10 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        #[pallet::weight(100_000)]
+        // TODO:
+        // Using `max_weight` is fine but it should be subtracted a bit in the call since the processing logic of the call itself
+        // will consume some of that weight - it won't be just other VM execution.
+        #[pallet::weight(context.max_weight)]
         pub fn xvm_call(
             origin: OriginFor<T>,
             context: XvmContext,
@@ -54,13 +57,13 @@ pub mod pallet {
             input: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
             let from = ensure_signed(origin)?;
-            let _result = T::SyncVM::xvm_call(context, from, to, input);
+            let result = T::SyncVM::xvm_call(context, from, to, input);
 
             Self::deposit_event(Event::<T>::XvmCall {
                 result: Ok(Default::default()),
             }); // TODO: this event should probably be changed
 
-            Ok(().into())
+            Ok(Some(consumed_weight(&result)).into())
         }
 
         #[pallet::weight(100_000)]

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -39,16 +39,13 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(crate) fn deposit_event)]
     pub enum Event<T: Config> {
-        XvmCall { result: Result<Vec<u8>, Vec<u8>> },
-        XvmSend { result: bool },
-        XvmQuery { result: Vec<Vec<u8>> },
+        XvmCall { result: Result<Vec<u8>, XvmError> },
+        XvmSend { result: Result<Vec<u8>, XvmError> },
+        XvmQuery { result: Result<Vec<u8>, XvmError> },
     }
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        // TODO:
-        // Using `max_weight` is fine but it should be subtracted a bit in the call since the processing logic of the call itself
-        // will consume some of that weight - it won't be just other VM execution.
         #[pallet::weight(context.max_weight)]
         pub fn xvm_call(
             origin: OriginFor<T>,
@@ -63,15 +60,19 @@ pub mod pallet {
             context.max_weight = context.max_weight - PLACEHOLDER_WEIGHT;
 
             let result = T::SyncVM::xvm_call(context, from, to, input);
+            let consumed_weight = consumed_weight(&result);
 
             Self::deposit_event(Event::<T>::XvmCall {
-                result: Ok(Default::default()),
-            }); // TODO: this event should probably be changed
+                result: match result {
+                    Ok(result) => Ok(result.output),
+                    Err(result) => Err(result.error),
+                },
+            });
 
-            Ok(Some(consumed_weight(&result)).into())
+            Ok(Some(consumed_weight).into())
         }
 
-        #[pallet::weight(100_000)]
+        #[pallet::weight(context.max_weight)]
         pub fn xvm_send(
             origin: OriginFor<T>,
             context: XvmContext,
@@ -79,23 +80,29 @@ pub mod pallet {
             message: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
             let from = ensure_signed(origin)?;
-            let _result = T::AsyncVM::xvm_send(context, from, to, message);
+            let result = T::AsyncVM::xvm_send(context, from, to, message);
 
             Self::deposit_event(Event::<T>::XvmSend {
-                result: Default::default(),
-            }); // TODO: change this
+                result: match result {
+                    Ok(result) => Ok(result.output),
+                    Err(result) => Err(result.error),
+                },
+            });
 
             Ok(().into())
         }
 
-        #[pallet::weight(100_000)]
+        #[pallet::weight(context.max_weight)]
         pub fn xvm_query(origin: OriginFor<T>, context: XvmContext) -> DispatchResultWithPostInfo {
             let inbox = ensure_signed(origin)?;
-            let _result = T::AsyncVM::xvm_query(context, inbox);
+            let result = T::AsyncVM::xvm_query(context, inbox);
 
             Self::deposit_event(Event::<T>::XvmQuery {
-                result: Default::default(),
-            }); // TODO: change this
+                result: match result {
+                    Ok(result) => Ok(result.output),
+                    Err(result) => Err(result.error),
+                },
+            });
 
             Ok(().into())
         }

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -54,9 +54,12 @@ pub mod pallet {
             input: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
             let from = ensure_signed(origin)?;
-            let result = T::SyncVM::xvm_call(context, from, to, input);
+            let _result = T::SyncVM::xvm_call(context, from, to, input);
 
-            Self::deposit_event(Event::<T>::XvmCall { result });
+            Self::deposit_event(Event::<T>::XvmCall {
+                result: Ok(Default::default()),
+            }); // TODO: this event should probably be changed
+
             Ok(().into())
         }
 
@@ -68,9 +71,12 @@ pub mod pallet {
             message: Vec<u8>,
         ) -> DispatchResultWithPostInfo {
             let from = ensure_signed(origin)?;
-            let result = T::AsyncVM::xvm_send(context, from, to, message);
+            let _result = T::AsyncVM::xvm_send(context, from, to, message);
 
-            Self::deposit_event(Event::<T>::XvmSend { result });
+            Self::deposit_event(Event::<T>::XvmSend {
+                result: Default::default(),
+            }); // TODO: change this
+
             Ok(().into())
         }
 
@@ -80,9 +86,12 @@ pub mod pallet {
             context: XvmContext,
         ) -> DispatchResultWithPostInfo {
             let inbox = ensure_signed(origin)?;
-            let result = T::AsyncVM::xvm_query(context, inbox);
+            let _result = T::AsyncVM::xvm_query(context, inbox);
 
-            Self::deposit_event(Event::<T>::XvmQuery { result });
+            Self::deposit_event(Event::<T>::XvmQuery {
+                result: Default::default(),
+            }); // TODO: change this
+
             Ok(().into())
         }
     }

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -14,7 +14,7 @@ type BalanceOf<T> = <<T as pallet_contracts::Config>::Currency as Currency<
     <T as frame_system::Config>::AccountId,
 >>::Balance;
 
-impl<I, T> SyncVM<VmId, T::AccountId> for WASM<I, T>
+impl<I, T> SyncVM<T::AccountId> for WASM<I, T>
 where
     I: Get<VmId>,
     T: pallet_contracts::Config + frame_system::Config,
@@ -25,15 +25,10 @@ where
         I::get()
     }
 
-    fn xvm_call(
-        context: XvmContext<VmId>,
-        from: T::AccountId,
-        to: Vec<u8>,
-        input: Vec<u8>,
-    ) -> XvmResult {
+    fn xvm_call(context: XvmContext, from: T::AccountId, to: Vec<u8>, input: Vec<u8>) -> XvmResult {
         log::trace!(
             target: "xvm::WASM::xvm_call",
-            "Start WASM XVM: {:?}, {:?}, {:?}, {:?}",
+            "Start WASM XVM: {:?}, {:?}, {:?}",
             from, to, input,
         );
         let gas_limit = context.max_weight;

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -30,7 +30,7 @@ where
         from: T::AccountId,
         to: Vec<u8>,
         input: Vec<u8>,
-    ) -> Result<Vec<u8>, Vec<u8>> {
+    ) -> XvmResult {
         log::trace!(
             target: "xvm::WASM::xvm_call",
             "Start WASM XVM: {:?}, {:?}, {:?}, {:?}",
@@ -45,7 +45,11 @@ where
             gas_limit,
             None,
             input,
-        );
+        )
+        .map_err(|_| XvmCallError {
+            error: XvmError::ExecutionError(Vec::default()), // TODO: make error mapping make more sense
+            consumed_weight: PLACEHOLDER_WEIGHT,             // TODO: get correct weight?
+        })?;
 
         log::trace!(
             target: "xvm::WASM::xvm_call",
@@ -54,6 +58,9 @@ where
 
         // TODO: return error if call failure
         // TODO: return value in case of constant / view call
-        Ok(Default::default())
+        Ok(XvmCallOk {
+            output: Default::default(), // TODO: vec should be filled with data in case of query? Should be generic probably.
+            consumed_weight: res.actual_weight.unwrap_or(PLACEHOLDER_WEIGHT), // TODO: this should be max static weight if `None`
+        })
     }
 }

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -54,7 +54,6 @@ where
             "WASM XVM call result: {:?}", res
         );
 
-        // TODO: return value in case of constant / view call
         Ok(XvmCallOk {
             output: Default::default(), // TODO: Fill in with output from the call
             consumed_weight: res.actual_weight.unwrap_or(gas_limit),

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -4,7 +4,7 @@
 use codec::Decode;
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
-use pallet_evm::{AddressMapping, Precompile, GasWeightMapping};
+use pallet_evm::{AddressMapping, GasWeightMapping, Precompile};
 use pallet_xvm::XvmContext;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
@@ -84,7 +84,7 @@ where
 
         // Dispatch a call.
         // The underlying logic will handle updating used EVM gas based on the weight of the executed call.
-        // TODO: check XVM call weighing!
+        // TODO: XVM call weighing needs to be updated to consider this parameter!
         RuntimeHelper::<R>::try_dispatch(handle, origin, call)?;
 
         Ok(succeed(EvmDataWriter::new().write(true).build()))

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -70,7 +70,6 @@ where
         let remaining_gas = handle.remaining_gas();
         let remaining_weight = R::GasWeightMapping::gas_to_weight(remaining_gas);
         context.max_weight = remaining_weight;
-        context.call_depth = 1;
 
         let call_to = input.read::<Bytes>()?.0;
         let call_input = input.read::<Bytes>()?.0;

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -4,7 +4,7 @@
 use codec::Decode;
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
-use pallet_evm::{AddressMapping, Precompile};
+use pallet_evm::{AddressMapping, Precompile, GasWeightMapping};
 use pallet_xvm::XvmContext;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
@@ -62,8 +62,15 @@ where
 
         // Read arguments and check it
         let context_raw = input.read::<Bytes>()?;
-        let context: XvmContext = Decode::decode(&mut context_raw.0.as_ref())
-            .map_err(|_| revert("can not decode XVM context"))?;
+        let context: XvmContext<<R as pallet_xvm::Config>::VmId> =
+            Decode::decode(&mut context_raw.0.as_ref())
+                .map_err(|_| revert("can not decode XVM context"))?;
+
+        // Fetch the remaining gas (weight) available for execution
+        let remaining_gas = handle.remaining_gas();
+        let _remaining_weight = R::GasWeightMapping::gas_to_weight(remaining_gas);
+        // TODO: include this value into context!
+
         let call_to = input.read::<Bytes>()?.0;
         let call_input = input.read::<Bytes>()?.0;
 
@@ -76,6 +83,8 @@ where
         };
 
         // Dispatch a call.
+        // The underlying logic will handle updating used EVM gas based on the weight of the executed call.
+        // TODO: check XVM call weighing!
         RuntimeHelper::<R>::try_dispatch(handle, origin, call)?;
 
         Ok(succeed(EvmDataWriter::new().write(true).build()))

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -63,9 +63,8 @@ where
         // Read arguments and check it
         // TODO: This approach probably needs to be revised - does contract call need to specify gas/weight? Usually it is implicit.
         let context_raw = input.read::<Bytes>()?;
-        let mut context: XvmContext<<R as pallet_xvm::Config>::VmId> =
-            Decode::decode(&mut context_raw.0.as_ref())
-                .map_err(|_| revert("can not decode XVM context"))?;
+        let mut context: XvmContext = Decode::decode(&mut context_raw.0.as_ref())
+            .map_err(|_| revert("can not decode XVM context"))?;
 
         // Fetch the remaining gas (weight) available for execution
         let remaining_gas = handle.remaining_gas();

--- a/precompiles/xvm/src/mock.rs
+++ b/precompiles/xvm/src/mock.rs
@@ -198,7 +198,6 @@ impl pallet_evm::Config for Runtime {
 
 impl pallet_xvm::Config for Runtime {
     type Event = Event;
-    type VmId = u8;
     type SyncVM = ();
     type AsyncVM = ();
 }

--- a/precompiles/xvm/src/tests.rs
+++ b/precompiles/xvm/src/tests.rs
@@ -1,6 +1,7 @@
 use crate::mock::*;
 use crate::*;
 
+use codec::Encode;
 use precompile_utils::testing::*;
 use precompile_utils::EvmDataWriter;
 
@@ -40,13 +41,14 @@ fn wrong_argument_reverts() {
 
 #[test]
 fn correct_arguments_works() {
+    let context: XvmContext<u8> = Default::default();
     ExtBuilder::default().build().execute_with(|| {
         precompiles()
             .prepare_test(
                 TestAccount::Alice,
                 PRECOMPILE_ADDRESS,
                 EvmDataWriter::new_with_selector(Action::XvmCall)
-                    .write(Bytes(vec![0u8, 0u8]))
+                    .write(Bytes(context.encode()))
                     .write(Bytes(b"".to_vec()))
                     .write(Bytes(b"".to_vec()))
                     .write(Bytes(b"".to_vec()))

--- a/precompiles/xvm/src/tests.rs
+++ b/precompiles/xvm/src/tests.rs
@@ -41,7 +41,7 @@ fn wrong_argument_reverts() {
 
 #[test]
 fn correct_arguments_works() {
-    let context: XvmContext<u8> = Default::default();
+    let context: XvmContext = Default::default();
     ExtBuilder::default().build().execute_with(|| {
         precompiles()
             .prepare_test(


### PR DESCRIPTION
**Pull Request Summary**

The purpose of this PR is to provide a prototype implementation for gas handling in XVM.

### Description

When executing a contract within the context of XVM, different VMs and gas handling schemas will be present.
E.g. the most basic example is EVM and Partity's WASM - gas vs. native weight. Each unit of these measures represents
a different concept, although similar. However, both are encapsulated by **substrate's** native way of handling weight (or gas).

So it's natural to keep the handling of *gas* in XVM  context tied to the native weight system.

### Current Solution

We rely on native weight handling for XVM *gas* handling.

To take an example when EVM contract calls WASM contract:
- EVM contract call is made by a user who sets **gas_limit**
- during EVM contract execution, some gas is consumed and a XVM call is made towards a WASM contract
- XVM precompile handles the call - it reads the remaining available gas, converts it to native *weight* and passes it on as `max_weight` via an XVM call
- XVM pallet detects which VM is being called and delegates call handling to it, also passing the `max_weight` value to WASM handler
- WASM handler executes the call, limiting it by `max_weight`, and in the return value returns how much weight was actually spent
- weight of the XVM call is updated (it can only be REDUCED compared to the initial setting)
- EVM precompile handler detects the real weight used for the XVM call, converts it to gas and refunds unused gas if needed

Same goes for `WASM --> EVM` direction.

### Open Issues, Questions & Suggestions

1. We should remove Async VM until we actually need to implement it.
2. Using wrapped `Call` isn't good enough if we want to have a return value..
3. Weight in the XVM call should be subtracted by XVM execution cost itself. Requires proper benchmarking.
5. We should limit XVM call depth. Probably a good starting value is 1 or 2.
6. XvmContext needs to be revised - imo, contract shouldn't care about limiting gas consumption - it's implicit from the call. I'm not even sure what exactly should be passed via it.

**Check list**
- [x] Receive feedback from team (1)
- [x] Apply first feedback
- [x] TBD
