### PR TITLE
Correct weight refund in ds-chain-extension

### DIFF
--- a/chain-extensions/dapps-staking/Cargo.toml
+++ b/chain-extensions/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dapps-staking-chain-extension"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/chain-extensions/dapps-staking/src/lib.rs
+++ b/chain-extensions/dapps-staking/src/lib.rs
@@ -240,10 +240,13 @@ impl<T: pallet_dapps_staking::Config> ChainExtensionExec<T> for DappsStakingExte
                     contract,
                 );
 
-                env.adjust_weight(
-                    charged_weight,
-                    call_result.unwrap().actual_weight.unwrap_or(0),
-                );
+                let actual_weight = match call_result {
+                    Ok(e) => e.actual_weight,
+                    Err(e) => e.post_info.actual_weight,
+                };
+                if let Some(actual_weight) = actual_weight {
+                    env.adjust_weight(charged_weight, actual_weight);
+                }
 
                 return match call_result {
                     Err(e) => {


### PR DESCRIPTION
**Pull Request Summary**

Removes `unwrap()` from dapps-staking chain-extension and replaces it with an exhaustive result check.
