### PR TITLE
Reformat TOMLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ members = [
 	"precompiles/xcm",
 	"precompiles/xvm",
 
-    # Disabled due to incorrect nightly channel usage
+	# Disabled due to incorrect nightly channel usage
 	# "contracts/*",
 ]


### PR DESCRIPTION
Trivial change to fix accidentally broken formatting of `Cargo.toml`. 
