### PR TITLE
XCM precompile - transact

### DIFF
--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-evm-precompile-xcm"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Basic XCM support for EVM."
 edition = "2021"
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 log = "0.4.16"

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -12,7 +12,7 @@ interface XCM {
      * @param is_relay - set `true` for using relay chain as reserve
      * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
      * @param fee_index - index of asset_id item that should be used as a XCM fee
-     * @return A boolean confirming whether the XCM message sent.
+     * @return bool confirmation whether the XCM message sent.
      *
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
@@ -35,7 +35,7 @@ interface XCM {
      * @param is_relay - set `true` for using relay chain as reserve
      * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
      * @param fee_index - index of asset_id item that should be used as a XCM fee
-     * @return A boolean confirming whether the XCM message sent.
+     * @return bool confirmation whether the XCM message sent.
      *
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
@@ -54,18 +54,20 @@ interface XCM {
      * @dev Execute a transaction on a remote chain.
      * @param parachain_id - destination parachain Id (ignored if is_relay is true)
      * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
-     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain TODO: this is very weird...
+     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
      * @param payment_amount - amount of payment asset to use for execution payment
-     * @param weight - max weight that remote transaction is allowed to consume
+     * @param total_weight - total weight we should buy execution time for. `payment_asset` should be sufficient to pay for this weight.
      * @param call - encoded call data (must be decodable by remote chain)
-     * @return A boolean confirming whether the XCM message sent.
+     * @param call_weight - max weight that remote call can consume. This can be measured on the destination chain.
+     * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
         uint256 parachain_id,
         bool is_relay,
         address payment_asset_id,
         uint256 payment_amount,
-        uint64 weight,
-        bytes calldata call
+        uint64 total_weight ,
+        bytes calldata call,
+        uint64 call_weight
     ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -49,4 +49,19 @@ interface XCM {
         uint256   parachain_id,
         uint256   fee_index
     ) external returns (bool);
+
+    /**
+     * TODO comprehensive docs
+     */
+    function remote_transact(
+        // TODO: Should we use a MultiLocation struct instead?
+        // It's less future proof and required destination might have to be something other than just pure parachain!
+        // TODO: related to previous TODO, but perhaps params should be revised?
+        uint256 parachain_id,
+        bool is_relay,
+        address payment_asset_id,
+        uint256 payment_amount,
+        uint64 weight,
+        bytes calldata call
+    ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -51,12 +51,16 @@ interface XCM {
     ) external returns (bool);
 
     /**
-     * TODO comprehensive docs
+     * @dev Execute a transaction on a remote chain.
+     * @param parachain_id - destination parachain Id (ignored if is_relay is true)
+     * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
+     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain TODO: this is very weird...
+     * @param payment_amount - amount of payment asset to use for execution payment
+     * @param weight - max weight that remote transaction is allowed to consume
+     * @param call - encoded call data (must be decodable by remote chain)
+     * @return A boolean confirming whether the XCM message sent.
      */
     function remote_transact(
-        // TODO: Should we use a MultiLocation struct instead?
-        // It's less future proof and required destination might have to be something other than just pure parachain!
-        // TODO: related to previous TODO, but perhaps params should be revised?
         uint256 parachain_id,
         bool is_relay,
         address payment_asset_id,

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -55,10 +55,9 @@ interface XCM {
      * @param parachain_id - destination parachain Id (ignored if is_relay is true)
      * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
      * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
-     * @param payment_amount - amount of payment asset to use for execution payment
-     * @param total_weight - total weight we should buy execution time for. `payment_asset` should be sufficient to pay for this weight.
+     * @param payment_amount - amount of payment asset to use for execution payment - should cover cost of XCM instructions + Transact call weight.
      * @param call - encoded call data (must be decodable by remote chain)
-     * @param call_weight - max weight that remote call can consume. This can be measured on the destination chain.
+     * @param transact_weight - max weight that the encoded call is allowed to consume in the destination chain
      * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
@@ -66,8 +65,7 @@ interface XCM {
         bool is_relay,
         address payment_asset_id,
         uint256 payment_amount,
-        uint64 total_weight ,
         bytes calldata call,
-        uint64 call_weight
+        uint64 transact_weight
     ) external returns (bool);
 }

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 pub enum Action {
     AssetsWithdrawNative = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
     AssetsWithdrawEvm = "assets_withdraw(address[],uint256[],address,bool,uint256,uint256)",
-    RemoteTransact = "remote_transact(uint256,bool,address,uint256,uint64,bytes,uint64)",
+    RemoteTransact = "remote_transact(uint256,bool,address,uint256,bytes,uint64)",
 }
 
 /// A precompile that expose XCM related functions.
@@ -177,25 +177,12 @@ where
         let fee_asset_addr = input.read::<Address>()?;
         let fee_amount = input.read::<U256>()?;
 
-        let total_weight = input.read::<u64>()?;
         let remote_call: Vec<u8> = input.read::<Bytes>()?.into();
-        let call_weight = input.read::<u64>()?;
+        let transact_weight = input.read::<u64>()?;
 
         log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset_addr: {:?}, \
-         fee_amount: {:?}, total_weight: {}, remote_call: {:?}, call_weight: {}",
-        para_id, is_relay, fee_asset_addr, fee_amount, total_weight, remote_call, call_weight);
-
-        // Sanity check
-        if call_weight > total_weight {
-            return Err(revert("Call weight cannot be greater than total weight"));
-        }
-        {
-            // Assumption that remote XCM instruction costs 1_000_000_000 units of weight
-            let remote_xcm_weight: u64 = 4 * 1_000_000_000;
-            if total_weight < call_weight.saturating_add(remote_xcm_weight) {
-                log::warn!("Total weight might not be enough to satisfy both XCM instructions weight and Transact weight.");
-            }
-        }
+         fee_amount: {:?}, remote_call: {:?}, transact_weight: {}",
+        para_id, is_relay, fee_asset_addr, fee_amount, remote_call, transact_weight);
 
         // Process arguments
         let dest = if is_relay {
@@ -230,11 +217,11 @@ where
             WithdrawAsset(fee_multilocation.clone().into()),
             BuyExecution {
                 fees: fee_multilocation.clone().into(),
-                weight_limit: WeightLimit::Limited(total_weight),
+                weight_limit: WeightLimit::Unlimited,
             },
             Transact {
                 origin_type: OriginKind::SovereignAccount,
-                require_weight_at_most: call_weight,
+                require_weight_at_most: transact_weight,
                 call: remote_call.into(),
             },
         ]);

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -9,7 +9,7 @@ use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 
 use xcm::latest::prelude::*;
-use xcm_executor::traits::Convert;
+use xcm_executor::traits::{Convert, InvertLocation};
 
 use pallet_evm_precompile_assets_erc20::AddressToAssetId;
 use precompile_utils::{
@@ -27,6 +27,7 @@ mod tests;
 pub enum Action {
     AssetsWithdrawNative = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
     AssetsWithdrawEvm = "assets_withdraw(address[],uint256[],address,bool,uint256,uint256)",
+    RemoteTransact = "remote_transact(uint256,bool,address,uint256,uint64,bytes)",
 }
 
 /// A precompile that expose XCM related functions.
@@ -56,6 +57,7 @@ where
                 Self::assets_withdraw(handle, BeneficiaryType::Account32)
             }
             Action::AssetsWithdrawEvm => Self::assets_withdraw(handle, BeneficiaryType::Account20),
+            Action::RemoteTransact => Self::remote_transact(handle),
         }
     }
 }
@@ -156,6 +158,80 @@ where
             beneficiary: Box::new(beneficiary.into()),
             assets: Box::new(assets.into()),
             fee_asset_item,
+        };
+
+        // Dispatch a call.
+        RuntimeHelper::<R>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
+    fn remote_transact(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(6)?;
+
+        // Raw call arguments
+        let para_id: u32 = input.read::<U256>()?.low_u32();
+        let is_relay = input.read::<bool>()?;
+
+        let fee_asset = input.read::<Address>()?;
+        let fee_amount = input.read::<U256>()?;
+
+        let weight = input.read::<u64>()?;
+        let remote_call = input.read::<Vec<u8>>()?;
+
+        log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset: {:?}, fee_amount: {:?}, weight: {}, remote_call: {:?}",
+        para_id, is_relay, fee_asset, fee_amount, weight, remote_call);
+
+        // Process arguments
+        let dest = if is_relay {
+            MultiLocation::parent()
+        } else {
+            X1(Junction::Parachain(para_id)).into_exterior(1)
+        };
+
+        // TODO: can this be written in a nicer format?
+        let fee_asset = R::address_to_asset_id(fee_asset.into())
+            .map(|x| {
+                C::reverse_ref(x)
+                    .map_err(|_| revert("Failed to resolve payment asset id from address"))
+            })
+            .ok_or(revert("Failed to resolve fee asset id from address"))??;
+        if fee_amount > u128::MAX.into() {
+            return Err(revert("Fee amount is too big"));
+        }
+        let fee_amount = fee_amount.low_u128();
+
+        // TODO: check if this is needed, or do SCs do this. Also, it might be incorrect.
+        let ancestry = R::LocationInverter::ancestry();
+        let fee_multilocation = MultiAsset {
+            id: Concrete(fee_asset),
+            fun: Fungible(fee_amount),
+        };
+        let fee_multilocation = fee_multilocation
+            .reanchored(&dest, &ancestry)
+            .map_err(|_| revert("Failed to reanchor fee asset"))?;
+
+        // Prepare XCM
+        // TODO
+        let xcm = Xcm(vec![
+            WithdrawAsset(fee_multilocation.clone().into()),
+            BuyExecution {
+                fees: fee_multilocation.into(),
+                weight_limit: WeightLimit::Limited(weight),
+            },
+            Transact {
+                origin_type: OriginKind::Native,
+                require_weight_at_most: weight,
+                call: remote_call.into(),
+            },
+        ]);
+
+        // Build call with origin.
+        let origin = Some(R::AddressMapping::into_account_id(handle.context().caller)).into();
+        let call = pallet_xcm::Call::<R>::send {
+            dest: Box::new(dest.into()),
+            message: Box::new(xcm::VersionedXcm::V2(xcm)), // TODO: why doesn't into() work here? Shouldn't need to wrap manually. Check polkadot repo.
         };
 
         // Dispatch a call.

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -13,8 +13,8 @@ use xcm_executor::traits::{Convert, InvertLocation};
 
 use pallet_evm_precompile_assets_erc20::AddressToAssetId;
 use precompile_utils::{
-    revert, succeed, Address, EvmDataWriter, EvmResult, FunctionModifier, PrecompileHandleExt,
-    RuntimeHelper,
+    revert, succeed, Address, Bytes, EvmDataWriter, EvmResult, FunctionModifier,
+    PrecompileHandleExt, RuntimeHelper,
 };
 
 #[cfg(test)]
@@ -178,7 +178,7 @@ where
         let fee_amount = input.read::<U256>()?;
 
         let weight = input.read::<u64>()?;
-        let remote_call = input.read::<Vec<u8>>()?;
+        let remote_call: Vec<u8> = input.read::<Bytes>()?.into();
 
         log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset_addr: {:?}, \
          fee_amount: {:?}, weight: {}, remote_call: {:?}",

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -27,7 +27,7 @@ mod tests;
 pub enum Action {
     AssetsWithdrawNative = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
     AssetsWithdrawEvm = "assets_withdraw(address[],uint256[],address,bool,uint256,uint256)",
-    RemoteTransact = "remote_transact(uint256,bool,address,uint256,uint64,bytes)",
+    RemoteTransact = "remote_transact(uint256,bool,address,uint256,uint64,bytes,uint64)",
 }
 
 /// A precompile that expose XCM related functions.

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -293,7 +293,7 @@ parameter_types! {
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
     type Call = Call;
-    type XcmSender = ();
+    type XcmSender = DoNothingRouter;
     type AssetTransactor = ();
     type OriginConverter = ();
     type IsReserve = ();
@@ -314,10 +314,17 @@ parameter_types! {
 
 pub type LocalOriginToLocation = SignedToAccountId32<Origin, AccountId, AnyNetwork>;
 
+pub struct DoNothingRouter;
+impl SendXcm for DoNothingRouter {
+    fn send_xcm(_dest: impl Into<MultiLocation>, _msg: Xcm<()>) -> SendResult {
+        Ok(())
+    }
+}
+
 impl pallet_xcm::Config for Runtime {
     type Event = Event;
     type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
-    type XcmRouter = ();
+    type XcmRouter = DoNothingRouter;
     type ExecuteXcmOrigin = xcm_builder::EnsureXcmOrigin<Origin, LocalOriginToLocation>;
     type XcmExecuteFilter = Everything;
     type XcmExecutor = XcmExecutor<XcmConfig>;

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -100,6 +100,7 @@ fn remote_transact_works() {
                     .write(U256::from(367))
                     .write(U256::from(10_000_000_000u64))
                     .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
+                    .write(U256::from(3_000_000_000u64))
                     .build(),
             )
             .expect_no_logs()

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -84,3 +84,25 @@ fn correct_arguments_works() {
             .execute_returns(EvmDataWriter::new().write(true).build());
     });
 }
+
+#[test]
+fn remote_transact_works() {
+    ExtBuilder::default().build().execute_with(|| {
+        // SS58
+        precompiles()
+            .prepare_test(
+                TestAccount::Alice,
+                PRECOMPILE_ADDRESS,
+                EvmDataWriter::new_with_selector(Action::RemoteTransact)
+                    .write(U256::from(0_u64))
+                    .write(true)
+                    .write(Address::from(Runtime::asset_id_to_address(1_u128)))
+                    .write(U256::from(367))
+                    .write(U256::from(10_000_000_000u64))
+                    .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
+                    .build(),
+            )
+            .expect_no_logs()
+            .execute_returns(EvmDataWriter::new().write(true).build());
+    });
+}

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -98,7 +98,6 @@ fn remote_transact_works() {
                     .write(true)
                     .write(Address::from(Runtime::asset_id_to_address(1_u128)))
                     .write(U256::from(367))
-                    .write(U256::from(10_000_000_000u64))
                     .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
                     .write(U256::from(3_000_000_000u64))
                     .build(),


### PR DESCRIPTION
**Pull Request Summary**

Support for using `Transact` instruction remotely on other chains via EVM smart contracts.

This enables smart contracts to send an arbitrary call to any chain Astar/Shiden has an open channel with.
User needs to specify a couple of arguments:
- `destination` - parachain Id or relay chain
- `payment asset & amount` - to use on the destination chain
  - user should have enough asset on the destination chain
- `weight` - total execution weight in the destination chain - sum of 4 XCM instructions executions + weight required to execute the encoded call via `Transact`
- `call` - remote encoded call - this is what will be executed on the destination chain 

The template message being sent looks like this:
1. DescendOrigin
2. WithdrawAsset
3. BuyExecution
4. Transact

User doesn't have control over this, except for the aforementioned configurable parameters.

**Open Questions**
- **Q1** - destination chain needs to support `DescendOrigin` and converting e.g. `AccountId32` into appropriate local representation. Will this work with chains like Moonbeam where `AccountKey20` is the default account representation type?
- **A** - yes because we don't control direct mapping of our address in the destination chain but most likely a mapping achieved by hashing our multilocation with additional fixed data to derive new address
- **Q2** - should there be `Refund` and `DepositAsset` instructions? Or should user ensure they use the correct weight and payment amount? This DOES make the transaction more expensive so perhaps it's better to leave it for future improvement.

**Check list**
- [x] extend UTs or create an item to improve XCM precompile tests
- [x] added unit tests
- [x] updated documentation
