### PR TITLE
use paritytech substrate for pallet-uniques

### DIFF
--- a/chain-extensions/rmrk/Cargo.toml
+++ b/chain-extensions/rmrk/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = { version = "0.2", default-features = false }
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false, features = ["unstable-interface"] }
 pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 pallet-contracts-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
-pallet-uniques = { git = "https://github.com/AstarNetwork/substrate.git", branch = "polkadot-v0.9.29", default-features = false }
+pallet-uniques = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.29", default-features = false }
 scale-info = { version = "2.1.0", default-features = false, features = ["derive"] }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29", default-features = false }


### PR DESCRIPTION
**Pull Request Summary**
Use `paritytech/substrate` to avoid dependency conflictions

pallet-uniques issue is already resolved https://github.com/paritytech/substrate/issues/12304, so no need to use forked repo only for uniques now (`AstarNetwork/substrate`).

**Check list**
- [ not applicable] added unit tests
- [not applicable ] updated documentation
