### PR TITLE
dApps staking max encoded len

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.6.3"
+version = "3.7.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -227,7 +227,7 @@ impl<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> EraStake<Balance> {
 ///
 /// **NOTE:** It is important to understand that staker **DID NOT** claim any rewards during this period.
 ///
-#[derive(Encode, Decode, Clone, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)] // TODO! MaxEncodedLen
+#[derive(Encode, Decode, Clone, Default, PartialEq, Eq, RuntimeDebug, TypeInfo)]
 pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> {
     // Size of this list would be limited by a configurable constant
     stakes: Vec<EraStake<Balance>>,
@@ -235,7 +235,7 @@ pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> {
 
 impl<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> MaxEncodedLen for StakerInfo<Balance> {
     fn max_encoded_len() -> usize {
-        123_usize
+        0_usize
     }
 }
 
@@ -412,7 +412,6 @@ where
 /// This is a convenience struct that provides various utility methods to help with unbonding handling.
 #[derive(Clone, PartialEq, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
 pub struct UnbondingInfo<Balance: AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen> {
-    // TODO
     // Vector of unlocking chunks. Sorted in ascending order in respect to unlock_era.
     unlocking_chunks: Vec<UnlockingChunk<Balance>>,
 }

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -80,18 +80,22 @@ pub type BalanceOf<T> =
 /// Counter for the number of eras that have passed.
 pub type EraIndex = u32;
 
-// This represents the max assumed vector length that any storage item should have. In particular, this relates to `UnbondingInfo` and `StakerInfo`.
+// This represents the max assumed vector length that any storage item should have.
+// In particular, this relates to `UnbondingInfo` and `StakerInfo`.
 // In structs which are bound in size, `MaxEncodedLen` can just be derived but that's not the case for standard `vec`.
 // To fix this 100% correctly, we'd need to do one of the following:
 //
 // - Use `BoundedVec` instead of `Vec` and do storage migration
-// - Introduce a new type `S: Get<u32>` into the aforementioned structs and use it to inject max allowed size, thus allowing us to correctly calculate max encoded len
+// - Introduce a new type `S: Get<u32>` into the aforementioned structs and use it to inject max allowed size,
+//   thus allowing us to correctly calculate max encoded len
 //
-// The issue with first approach is that it requires storage migration which we want to avoid unless it's really necessary.
-// The issue with second approach is that it makes code much more difficult to work with since all of it will be ridden with injections of the `S` type.
+// The issue with first approach is that it requires storage migration which we want to avoid
+// unless it's really necessary. The issue with second approach is that it makes code much more
+// difficult to work with since all of it will be ridden with injections of the `S` type.
 //
-// Since dApps staking has been stable for long time and there are plans to redesign & refactor it, doing neither of the above makes sense, timewise.
-// So we use an assumption that Vec length won't go over the following constant.
+// Since dApps staking has been stable for long time and there are plans to redesign & refactor it,
+// doing neither of the above makes sense, timewise. So we use an assumption that vec length
+// won't go over the following constant.
 const MAX_ASSUMED_VEC_LEN: u32 = 10;
 
 /// DApp State descriptor

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -80,6 +80,20 @@ pub type BalanceOf<T> =
 /// Counter for the number of eras that have passed.
 pub type EraIndex = u32;
 
+// This represents the max assumed vector length that any storage item should have. In particular, this relates to `UnbondingInfo` and `StakerInfo`.
+// In structs which are bound in size, `MaxEncodedLen` can just be derived but that's not the case for standard `vec`.
+// To fix this 100% correctly, we'd need to do one of the following:
+//
+// - Use `BoundedVec` instead of `Vec` and do storage migration
+// - Introduce a new type `S: Get<u32>` into the aforementioned structs and use it to inject max allowed size, thus allowing us to correctly calculate max encoded len
+//
+// The issue with first approach is that it requires storage migration which we want to avoid unless it's really necessary.
+// The issue with second approach is that it makes code much more difficult to work with since all of it will be ridden with injections of the `S` type.
+// 
+// Since dApps staking has been stable for long time and there are plans to redesign & refactor it, doing neither of the above makes sense, timewise.
+// So we use an assumption that Vec len won't go over the following constant.
+const MAX_ASSUMED_VEC_LEN: u32 = 10;
+
 /// DApp State descriptor
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 enum DAppState {
@@ -234,8 +248,11 @@ pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> {
 }
 
 impl<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> MaxEncodedLen for StakerInfo<Balance> {
+    // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
     fn max_encoded_len() -> usize {
-        0_usize
+		codec::Compact(MAX_ASSUMED_VEC_LEN)
+			.encoded_size()
+			.saturating_add((MAX_ASSUMED_VEC_LEN as usize).saturating_mul(Balance::max_encoded_len()))
     }
 }
 
@@ -420,7 +437,12 @@ impl<Balance: AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen> MaxEncodedL
     for UnbondingInfo<Balance>
 {
     fn max_encoded_len() -> usize {
-        0_usize
+        // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
+        fn max_encoded_len() -> usize {
+            codec::Compact(MAX_ASSUMED_VEC_LEN)
+                .encoded_size()
+                .saturating_add((MAX_ASSUMED_VEC_LEN as usize).saturating_mul(Balance::max_encoded_len()))
+        }
     }
 }
 

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -89,9 +89,9 @@ pub type EraIndex = u32;
 //
 // The issue with first approach is that it requires storage migration which we want to avoid unless it's really necessary.
 // The issue with second approach is that it makes code much more difficult to work with since all of it will be ridden with injections of the `S` type.
-// 
+//
 // Since dApps staking has been stable for long time and there are plans to redesign & refactor it, doing neither of the above makes sense, timewise.
-// So we use an assumption that Vec len won't go over the following constant.
+// So we use an assumption that Vec length won't go over the following constant.
 const MAX_ASSUMED_VEC_LEN: u32 = 10;
 
 /// DApp State descriptor
@@ -250,9 +250,12 @@ pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> {
 impl<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> MaxEncodedLen for StakerInfo<Balance> {
     // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
     fn max_encoded_len() -> usize {
-		codec::Compact(MAX_ASSUMED_VEC_LEN)
-			.encoded_size()
-			.saturating_add((MAX_ASSUMED_VEC_LEN as usize).saturating_mul(Balance::max_encoded_len()))
+        codec::Compact(MAX_ASSUMED_VEC_LEN)
+            .encoded_size()
+            .saturating_add(
+                (MAX_ASSUMED_VEC_LEN as usize)
+                    .saturating_mul(EraStake::<Balance>::max_encoded_len()),
+            )
     }
 }
 
@@ -436,13 +439,14 @@ pub struct UnbondingInfo<Balance: AtLeast32BitUnsigned + Default + Copy + MaxEnc
 impl<Balance: AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen> MaxEncodedLen
     for UnbondingInfo<Balance>
 {
+    // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
     fn max_encoded_len() -> usize {
-        // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
-        fn max_encoded_len() -> usize {
-            codec::Compact(MAX_ASSUMED_VEC_LEN)
-                .encoded_size()
-                .saturating_add((MAX_ASSUMED_VEC_LEN as usize).saturating_mul(Balance::max_encoded_len()))
-        }
+        codec::Compact(MAX_ASSUMED_VEC_LEN)
+            .encoded_size()
+            .saturating_add(
+                (MAX_ASSUMED_VEC_LEN as usize)
+                    .saturating_mul(UnlockingChunk::<Balance>::max_encoded_len()),
+            )
     }
 }
 

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 };
 use sp_core::{H160, H256};
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,
@@ -144,7 +144,9 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxEraStakeValues = MaxEraStakeValues;
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, scale_info::TypeInfo)]
+#[derive(
+    PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, scale_info::TypeInfo, MaxEncodedLen,
+)]
 pub enum MockSmartContract<AccountId> {
     Evm(sp_core::H160),
     Wasm(AccountId),

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -32,7 +32,6 @@ pub mod pallet {
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(crate) trait Store)]
-    #[pallet::without_storage_info]
     pub struct Pallet<T>(PhantomData<T>);
 
     // Negative imbalance type of this pallet.
@@ -47,7 +46,7 @@ pub mod pallet {
             + ReservableCurrency<Self::AccountId>;
 
         /// Describes smart contract in the context required by dapps staking.
-        type SmartContract: Default + Parameter + Member;
+        type SmartContract: Default + Parameter + Member + MaxEncodedLen;
 
         /// Number of blocks per era.
         #[pallet::constant]

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2135,9 +2135,15 @@ pub fn set_contract_stake_info() {
 
 #[test]
 fn custom_max_encoded_len() {
-    // 10 x (4 + 16) + 1 = 10 x 20 + 1 = 201
-    assert_eq!(UnbondingInfo::<u128>::max_encoded_len(), 201);
+    let max_unbonding_info_len = 10 * (4 + 16) + 1;
+    assert_eq!(
+        UnbondingInfo::<u128>::max_encoded_len(),
+        max_unbonding_info_len as usize
+    );
 
-    // 10 x (4 + 16) + 1 = 10 x 20 + 1 = 201
-    assert_eq!(StakerInfo::<u128>::max_encoded_len(), 201);
+    let max_staker_info_len = 10 * (4 + 16) + 1;
+    assert_eq!(
+        StakerInfo::<u128>::max_encoded_len(),
+        max_staker_info_len as usize
+    );
 }

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2132,3 +2132,12 @@ pub fn set_contract_stake_info() {
         );
     })
 }
+
+#[test]
+fn custom_max_encoded_len() {
+    // 10 x (4 + 16) + 1 = 10 x 20 + 1 = 201
+    assert_eq!(UnbondingInfo::<u128>::max_encoded_len(), 201);
+
+    // 10 x (4 + 16) + 1 = 10 x 20 + 1 = 201
+    assert_eq!(StakerInfo::<u128>::max_encoded_len(), 201);
+}

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -234,7 +234,9 @@ impl pallet_timestamp::Config for TestRuntime {
     type WeightInfo = ();
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, scale_info::TypeInfo)]
+#[derive(
+    PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, scale_info::TypeInfo, MaxEncodedLen,
+)]
 pub enum MockSmartContract<AccountId32> {
     Evm(sp_core::H160),
     Wasm(AccountId32),


### PR DESCRIPTION
**Pull Request Summary**

Removes `without_storage_info` from the `pallet-dapps-staking` crate.
Introduces derivation of `MaxEncodedLen` trait to all possible structs, enums and types.

For the `UnbondingInfo` and `StakerInfo`, an assumption is introduced that their length won't go over a specific constant.
Since we're fully in control of runtime code, we can be fairly sure this limitation won't be exceeded. Also, dApps staking is a stable feature and there is no reason to modify current parameters from what they currently are.

See code more more detailed explanation & comments.
