### PR TITLE
DappsStaking bench improvements

### DIFF
--- a/frame/collator-selection/src/tests.rs
+++ b/frame/collator-selection/src/tests.rs
@@ -117,7 +117,9 @@ fn cannot_register_candidate_if_too_many() {
 
         // reset desired candidates:
         <crate::DesiredCandidates<Test>>::put(1);
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
 
         // but no more
         assert_noop!(
@@ -132,7 +134,9 @@ fn cannot_unregister_candidate_if_too_few() {
     new_test_ext().execute_with(|| {
         // reset desired candidates:
         <crate::DesiredCandidates<Test>>::put(1);
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
 
         // can not remove too few
         assert_noop!(
@@ -170,7 +174,9 @@ fn cannot_register_as_candidate_if_keys_not_registered() {
 fn cannot_register_dupe_candidate() {
     new_test_ext().execute_with(|| {
         // can add 3 as candidate
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
         let addition = CandidateInfo {
             who: 3,
             deposit: 10,
@@ -194,7 +200,9 @@ fn cannot_register_as_candidate_if_poor() {
         assert_eq!(Balances::free_balance(&33), 0);
 
         // works
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
 
         // poor
         assert_noop!(
@@ -217,8 +225,12 @@ fn register_as_candidate_works() {
         assert_eq!(Balances::free_balance(&3), 100);
         assert_eq!(Balances::free_balance(&4), 100);
 
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
 
         assert_eq!(Balances::free_balance(&3), 90);
         assert_eq!(Balances::free_balance(&4), 90);
@@ -231,11 +243,15 @@ fn register_as_candidate_works() {
 fn leave_intent() {
     new_test_ext().execute_with(|| {
         // register a candidate.
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
         assert_eq!(Balances::free_balance(3), 90);
 
         // register too so can leave above min candidates
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(5)
+        ));
         assert_eq!(Balances::free_balance(5), 90);
 
         // cannot leave if not candidate.
@@ -259,7 +275,9 @@ fn authorship_event_handler() {
 
         // 4 is the default author.
         assert_eq!(Balances::free_balance(4), 100);
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
         // triggers `note_author`
         Authorship::on_initialize(1);
 
@@ -287,7 +305,9 @@ fn fees_edgecases() {
         Balances::make_free_balance_be(&CollatorSelection::account_id(), 5);
         // 4 is the default author.
         assert_eq!(Balances::free_balance(4), 100);
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
         // triggers `note_author`
         Authorship::on_initialize(1);
 
@@ -319,7 +339,9 @@ fn session_management_works() {
         assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
 
         // add a new collator
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
 
         // session won't see this.
         assert_eq!(SessionHandlerCollators::get(), vec![1, 2]);
@@ -348,8 +370,12 @@ fn kick_and_slash_mechanism() {
         // Define slash destination account
         <crate::SlashDestination<Test>>::put(5);
         // add a new collator
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(4)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(4)
+        ));
         initialize_to_block(10);
         assert_eq!(CollatorSelection::candidates().len(), 2);
         initialize_to_block(20);
@@ -377,8 +403,12 @@ fn kick_and_slash_mechanism() {
 fn should_not_kick_mechanism_too_few() {
     new_test_ext().execute_with(|| {
         // add a new collator
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(3)));
-        assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(5)));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(3)
+        ));
+        assert_ok!(CollatorSelection::register_as_candidate(
+            RuntimeOrigin::signed(5)
+        ));
         initialize_to_block(10);
         assert_eq!(CollatorSelection::candidates().len(), 2);
         initialize_to_block(20);

--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.7.0"
+version = "3.8.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -103,6 +103,7 @@ pub mod pallet {
 
     /// Denotes whether pallet is disabled (in maintenance mode) or not
     #[pallet::storage]
+    #[pallet::whitelist_storage]
     #[pallet::getter(fn pallet_disabled)]
     pub type PalletDisabled<T: Config> = StorageValue<_, bool, ValueQuery>;
 
@@ -130,11 +131,13 @@ pub mod pallet {
 
     /// Mode of era forcing.
     #[pallet::storage]
+    #[pallet::whitelist_storage]
     #[pallet::getter(fn force_era)]
     pub type ForceEra<T> = StorageValue<_, Forcing, ValueQuery, ForceEraOnEmpty>;
 
     /// Stores the block number of when the next era starts
     #[pallet::storage]
+    #[pallet::whitelist_storage]
     #[pallet::getter(fn next_era_starting_block)]
     pub type NextEraStartingBlock<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
 

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -114,6 +114,7 @@ pub mod pallet {
 
     /// The current era index.
     #[pallet::storage]
+    #[pallet::whitelist_storage]
     #[pallet::getter(fn current_era)]
     pub type CurrentEra<T> = StorageValue<_, EraIndex, ValueQuery>;
 

--- a/frame/dapps-staking/src/testing_utils.rs
+++ b/frame/dapps-staking/src/testing_utils.rs
@@ -158,11 +158,9 @@ pub(crate) fn assert_withdraw_from_unregistered(
         RuntimeOrigin::signed(staker.clone()),
         contract_id.clone()
     ));
-    System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::WithdrawFromUnregistered(
-        staker,
-        contract_id.clone(),
-        staked_value,
-    )));
+    System::assert_last_event(mock::RuntimeEvent::DappsStaking(
+        Event::WithdrawFromUnregistered(staker, contract_id.clone(), staked_value),
+    ));
 
     let final_state = MemorySnapshot::all(current_era, contract_id, staker);
 
@@ -365,7 +363,9 @@ pub(crate) fn assert_withdraw_unbonded(staker: AccountId) {
     let expected_unbond_amount = valid_info.sum();
 
     // Ensure op is successful and event is emitted
-    assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(staker),));
+    assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(
+        staker
+    ),));
     System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::Withdrawn(
         staker,
         expected_unbond_amount,

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -120,7 +120,9 @@ fn new_era_is_handled_with_maintenance_mode() {
         // enable maintenance mode
         assert_ok!(DappsStaking::maintenance_mode(RuntimeOrigin::root(), true));
         assert!(PalletDisabled::<TestRuntime>::exists());
-        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(true)));
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(
+            true,
+        )));
 
         // advance 9 blocks or 3 era lengths (advance_to_era() doesn't work in maintenance mode)
         run_for_blocks(mock::BLOCKS_PER_ERA * 3);
@@ -131,7 +133,9 @@ fn new_era_is_handled_with_maintenance_mode() {
 
         // disable maintenance mode
         assert_ok!(DappsStaking::maintenance_mode(RuntimeOrigin::root(), false));
-        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(false)));
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(
+            false,
+        )));
 
         // advance one era
         run_for_blocks(mock::BLOCKS_PER_ERA);
@@ -479,7 +483,11 @@ fn unregister_stake_and_unstake_is_not_ok() {
             Error::<TestRuntime>::NotOperatedContract
         );
         assert_noop!(
-            DappsStaking::unbond_and_unstake(RuntimeOrigin::signed(staker), contract_id.clone(), 100),
+            DappsStaking::unbond_and_unstake(
+                RuntimeOrigin::signed(staker),
+                contract_id.clone(),
+                100
+            ),
             Error::<TestRuntime>::NotOperatedContract
         );
     })
@@ -622,7 +630,10 @@ fn withdraw_from_unregistered_when_unclaimed_rewards_remaining() {
 
         for _ in 1..DappsStaking::current_era() {
             assert_noop!(
-                DappsStaking::withdraw_from_unregistered(RuntimeOrigin::signed(staker), contract_id),
+                DappsStaking::withdraw_from_unregistered(
+                    RuntimeOrigin::signed(staker),
+                    contract_id
+                ),
                 Error::<TestRuntime>::UnclaimedRewardsRemaining
             );
             assert_claim_staker(staker, &contract_id);
@@ -746,7 +757,11 @@ fn bond_and_stake_on_unregistered_contract_fails() {
         // Check not registered contract. Expect an error.
         let evm_contract = MockSmartContract::Evm(H160::repeat_byte(0x01));
         assert_noop!(
-            DappsStaking::bond_and_stake(RuntimeOrigin::signed(staker_id), evm_contract, stake_value),
+            DappsStaking::bond_and_stake(
+                RuntimeOrigin::signed(staker_id),
+                evm_contract,
+                stake_value
+            ),
             Error::<TestRuntime>::NotOperatedContract
         );
     })
@@ -1053,7 +1068,11 @@ fn unbond_and_unstake_with_no_chunks_allowed() {
         assert_bond_and_stake(staker_id, &contract_id, 100);
 
         assert_noop!(
-            DappsStaking::unbond_and_unstake(RuntimeOrigin::signed(staker_id), contract_id.clone(), 20),
+            DappsStaking::unbond_and_unstake(
+                RuntimeOrigin::signed(staker_id),
+                contract_id.clone(),
+                20
+            ),
             Error::<TestRuntime>::TooManyUnlockingChunks,
         );
     })
@@ -1090,7 +1109,9 @@ fn withdraw_unbonded_is_ok() {
 
         // Advance one additional era and expect that the first chunk can be withdrawn
         advance_to_era(DappsStaking::current_era() + 1);
-        assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(staker_id),));
+        assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(
+            staker_id
+        ),));
         System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::Withdrawn(
             staker_id,
             first_unbond_value,
@@ -1098,7 +1119,9 @@ fn withdraw_unbonded_is_ok() {
 
         // Advance one additional era and expect that the first chunk can be withdrawn
         advance_to_era(DappsStaking::current_era() + 1);
-        assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(staker_id),));
+        assert_ok!(DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(
+            staker_id
+        ),));
         System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::Withdrawn(
             staker_id,
             second_unbond_value,
@@ -1420,7 +1443,11 @@ fn nomination_transfer_contracts_have_too_many_era_stake_values() {
             advance_to_era(DappsStaking::current_era() + 1);
         }
         assert_noop!(
-            DappsStaking::bond_and_stake(RuntimeOrigin::signed(staker), origin_contract_id.clone(), 15),
+            DappsStaking::bond_and_stake(
+                RuntimeOrigin::signed(staker),
+                origin_contract_id.clone(),
+                15
+            ),
             Error::<TestRuntime>::TooManyEraStakeValues
         );
 
@@ -1656,7 +1683,10 @@ fn claim_is_ok() {
         // Shouldn't be possible to claim current era.
         // Also, previous claim calls should have claimed everything prior to current era.
         assert_noop!(
-            DappsStaking::claim_staker(RuntimeOrigin::signed(first_staker), first_contract_id.clone()),
+            DappsStaking::claim_staker(
+                RuntimeOrigin::signed(first_staker),
+                first_contract_id.clone()
+            ),
             Error::<TestRuntime>::EraOutOfBounds
         );
         assert_noop!(
@@ -1716,7 +1746,11 @@ fn claim_after_unregister_is_ok() {
         for era in start_era..unregister_era {
             if era >= full_unstake_era && era < restake_era {
                 assert_noop!(
-                    DappsStaking::claim_dapp(RuntimeOrigin::signed(developer), contract_id.clone(), era),
+                    DappsStaking::claim_dapp(
+                        RuntimeOrigin::signed(developer),
+                        contract_id.clone(),
+                        era
+                    ),
                     Error::<TestRuntime>::NotStakedContract
                 );
             } else {
@@ -1896,7 +1930,11 @@ fn claim_dapp_with_zero_stake_periods_is_ok() {
         // Ensure that the empty interval cannot be claimed
         for era in first_full_unstake_era..restake_era {
             assert_noop!(
-                DappsStaking::claim_dapp(RuntimeOrigin::signed(developer), contract_id.clone(), era),
+                DappsStaking::claim_dapp(
+                    RuntimeOrigin::signed(developer),
+                    contract_id.clone(),
+                    era
+                ),
                 Error::<TestRuntime>::NotStakedContract
             );
         }
@@ -1934,7 +1972,9 @@ fn maintenance_mode_is_ok() {
 
         assert_ok!(DappsStaking::maintenance_mode(RuntimeOrigin::root(), true));
         assert!(PalletDisabled::<TestRuntime>::exists());
-        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(true)));
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(
+            true,
+        )));
 
         let account = 1;
         let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
@@ -1998,7 +2038,9 @@ fn maintenance_mode_is_ok() {
         //
         // 4
         assert_ok!(DappsStaking::maintenance_mode(RuntimeOrigin::root(), false));
-        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(false)));
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::MaintenanceMode(
+            false,
+        )));
         assert_register(account, &contract_id);
     })
 }

--- a/frame/pallet-xvm/Cargo.toml
+++ b/frame/pallet-xvm/Cargo.toml
@@ -22,7 +22,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30", optional = true, default-features = false }
 
 # EVM support 
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, optional = true, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, optional = true, features = ["forbid-evm-reentrancy"] }
 
 # Substrate WASM VM support
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.30", default-features = false, optional = true }

--- a/frame/xc-asset-config/src/tests.rs
+++ b/frame/xc-asset-config/src/tests.rs
@@ -95,10 +95,12 @@ fn register_asset_location_and_units_per_sec_is_ok() {
             Box::new(asset_location.clone().versioned()),
             units
         ));
-        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(Event::UnitsPerSecondChanged {
-            asset_location: asset_location.clone().versioned(),
-            units_per_second: units,
-        }));
+        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(
+            Event::UnitsPerSecondChanged {
+                asset_location: asset_location.clone().versioned(),
+                units_per_second: units,
+            },
+        ));
         assert_eq!(
             AssetLocationUnitsPerSecond::<Test>::get(&asset_location.clone().versioned()).unwrap(),
             units
@@ -164,11 +166,13 @@ fn change_asset_location_is_ok() {
             Box::new(new_asset_location.clone().versioned()),
             asset_id
         ));
-        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(Event::AssetLocationChanged {
-            previous_asset_location: asset_location.clone().versioned(),
-            asset_id: asset_id,
-            new_asset_location: new_asset_location.clone().versioned(),
-        }));
+        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(
+            Event::AssetLocationChanged {
+                previous_asset_location: asset_location.clone().versioned(),
+                asset_id: asset_id,
+                new_asset_location: new_asset_location.clone().versioned(),
+            },
+        ));
 
         // Assert storage state
         assert_eq!(
@@ -217,9 +221,11 @@ fn remove_payment_asset_is_ok() {
             RuntimeOrigin::root(),
             Box::new(asset_location.clone().versioned()),
         ));
-        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(Event::SupportedAssetRemoved {
-            asset_location: asset_location.clone().versioned(),
-        }));
+        System::assert_last_event(mock::RuntimeEvent::XcAssetConfig(
+            Event::SupportedAssetRemoved {
+                asset_location: asset_location.clone().versioned(),
+            },
+        ));
         assert!(!AssetLocationUnitsPerSecond::<Test>::contains_key(
             asset_location.clone().versioned()
         ));

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -25,7 +25,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -25,7 +25,7 @@ pallet-dapps-staking = { path = "../../frame/dapps-staking", default-features = 
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 [dev-dependencies]
 derive_more = "0.99"

--- a/precompiles/dapps-staking/src/tests.rs
+++ b/precompiles/dapps-staking/src/tests.rs
@@ -383,7 +383,12 @@ fn nomination_transfer() {
 fn register_and_verify(developer: TestAccount, contract: H160) {
     let smart_contract =
         decode_smart_contract_from_array(contract.clone().to_fixed_bytes()).unwrap();
-    DappsStaking::register(RuntimeOrigin::root(), developer.clone().into(), smart_contract).unwrap();
+    DappsStaking::register(
+        RuntimeOrigin::root(),
+        developer.clone().into(),
+        smart_contract,
+    )
+    .unwrap();
 
     // check the storage after the register
     let dev_account_id: AccountId32 = developer.into();

--- a/precompiles/sr25519/Cargo.toml
+++ b/precompiles/sr25519/Cargo.toml
@@ -18,7 +18,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 [dev-dependencies]
 derive_more = "0.99"

--- a/precompiles/substrate-ecdsa/Cargo.toml
+++ b/precompiles/substrate-ecdsa/Cargo.toml
@@ -18,7 +18,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 [dev-dependencies]
 derive_more = "0.99"

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -27,7 +27,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 # Polkadot / XCM
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.30", default-features = false }

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -23,7 +23,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 # Polkadot
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.30", default-features = false }

--- a/precompiles/xvm/Cargo.toml
+++ b/precompiles/xvm/Cargo.toml
@@ -21,7 +21,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.30", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 [dev-dependencies]
 derive_more = "0.99"


### PR DESCRIPTION
**Pull Request Summary**
Dapps Staking `CurrentEra` storage value is accessed by `on_initialize` hook at every block.
That means current era value is available in overlay cache, thus we can ignore storage access from benchmarking.

New attribute macro `#[pallet::whitelist_storage]` registers Storage items to whitelists (which will be ignored in benchmarking), see more details https://github.com/paritytech/substrate/pull/12205.

This requires Astar repo updates too, but adding attribute can be done independently.


This PR fixes format issue as well `cargo fmt`, `taplo fmt` to pass merge blocking.