### PR TITLE
Custom barrier for DescendOrigin

### DIFF
--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcm-primitives"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Common XCM primitives used by runtimes"
 edition = "2021"
@@ -26,6 +26,7 @@ pallet-xc-asset-config = { path = "../../frame/xc-asset-config", default-feature
 [features]
 default = ["std"]
 std = [
+	"log/std",
 	"frame-support/std",
 	"sp-std/std",
 	"sp-runtime/std",

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -256,10 +256,8 @@ impl<
 /// payments into account.
 ///
 /// Only allows for sequence `DescendOrigin` -> `WithdrawAsset` -> `BuyExecution`
-pub struct AllowTopLevelPaidExecutionWithDescendOriginFrom<T>(PhantomData<T>);
-impl<T: Contains<MultiLocation>> ShouldExecute
-    for AllowTopLevelPaidExecutionWithDescendOriginFrom<T>
-{
+pub struct AllowPaidExecWithDescendOriginFrom<T>(PhantomData<T>);
+impl<T: Contains<MultiLocation>> ShouldExecute for AllowPaidExecWithDescendOriginFrom<T> {
     fn should_execute<RuntimeCall>(
         origin: &MultiLocation,
         message: &mut Xcm<RuntimeCall>,
@@ -268,7 +266,7 @@ impl<T: Contains<MultiLocation>> ShouldExecute
     ) -> Result<(), ()> {
         log::trace!(
             target: "xcm::barriers",
-            "AllowTopLevelPaidExecutionWithDescendOriginFrom origin: {:?}, message: {:?}, max_weight: {:?}, weight_credit: {:?}",
+            "AllowPaidExecWithDescendOriginFrom origin: {:?}, message: {:?}, max_weight: {:?}, weight_credit: {:?}",
             origin, message, max_weight, _weight_credit,
         );
         ensure!(T::contains(origin), ());
@@ -282,10 +280,7 @@ impl<T: Contains<MultiLocation>> ShouldExecute
 
         i = iter.next().ok_or(())?;
         match i {
-            ReceiveTeleportedAsset(..)
-            | WithdrawAsset(..)
-            | ReserveAssetDeposited(..)
-            | ClaimAsset { .. } => (),
+            WithdrawAsset(..) => (),
             _ => return Err(()),
         }
 


### PR DESCRIPTION
**Pull Request Summary**

Adds custom `Barrier` for `XCM` that allows sequence like:

`DescendOrigin -> WithdrawAsset -> BuyExecution`

This is required if we want to support remote execution from non-parachain accounts.
The common sense here is the assumption that none of the parachains would allow sending of customizable XCM sequence
that isn't prepended with `DescendOrigin`.

**Check list**
- [x] added unit tests
- [x] updated documentation
