### PR TITLE
Prevent double & incorrect charging of EVM-XVM gas fee

### DIFF
--- a/frame/pallet-xvm/Cargo.toml
+++ b/frame/pallet-xvm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-xvm"
 authors = ["Stake Technologies"]
 edition = "2021"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 impl-trait-for-tuples = "0.2"

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -27,6 +27,8 @@ where
             from, to, input,
         );
         let value = U256::zero();
+
+        // Tells the EVM executor that no fees should be charged for this execution.
         let max_fee_per_gas = U256::zero();
         let gas_limit = T::GasWeightMapping::weight_to_gas(context.max_weight);
         log::trace!(

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -26,8 +26,8 @@ where
             "Start EVM XVM: {:?}, {:?}, {:?}",
             from, to, input,
         );
-        let value = U256::from(0u64);
-        let max_fee_per_gas = U256::from(3450898690u64);
+        let value = U256::zero();
+        let max_fee_per_gas = U256::zero();
         let gas_limit = T::GasWeightMapping::weight_to_gas(context.max_weight);
         log::trace!(
             target: "xvm::EVM::xvm_call",

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -58,7 +58,7 @@ where
                 context.max_weight.ref_time()
             };
             XvmCallError {
-                error: XvmError::ExecutionError(Vec::default()), // TODO: make error mapping make more sense
+                error: XvmError::ExecutionError(Into::<&str>::into(e.error).into()),
                 consumed_weight,
             }
         })?;

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -72,7 +72,7 @@ where
         Ok(XvmCallOk {
             output: Default::default(), // TODO: Fill output vec with response from the call
             consumed_weight: T::GasWeightMapping::gas_to_weight(
-                info.unique_saturated_into(),
+                info.used_gas.unique_saturated_into(),
                 false,
             )
             .ref_time(),

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -62,6 +62,11 @@ pub mod pallet {
             let result = T::SyncVM::xvm_call(context, from, to, input);
             let consumed_weight = consumed_weight(&result);
 
+            log::trace!(
+                target: "xvm::pallet::xvm_call",
+                "Execution result: {:?}, consumed_weight: {:?}", result, consumed_weight,
+            );
+
             Self::deposit_event(Event::<T>::XvmCall {
                 result: match result {
                     Ok(result) => Ok(result.output),

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -54,7 +54,7 @@ where
                 gas_limit.ref_time()
             };
             XvmCallError {
-                error: XvmError::ExecutionError(Vec::default()), // TODO: make error mapping make more sense
+                error: XvmError::ExecutionError(Into::<&str>::into(e.error).into()),
                 consumed_weight,
             }
         })?;


### PR DESCRIPTION
**Pull Request Summary**

By specifying `max_fee_per_gas` to be `zero`, we instruct EVM executor not to charge the caller for gas fees.

This is ok since the XVM call will be charged in the context of its originating call.

EVM runner reference code: https://github.com/paritytech/frontier/blob/master/frame/evm/src/runner/stack.rs#L135


