### PR TITLE
Native currency in remote_transact

### DIFF
--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-evm-precompile-xcm"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Basic XCM support for EVM."
 edition = "2021"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 log = "0.4.16"


### PR DESCRIPTION
**Pull Request Summary**

Allow payment asset to be native currency in XCM precompile's `remote_transact`.

**Check list**
- [x] updated documentation
