### PR TITLE
Burn stale rewards

### DIFF
--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.8.0"
+version = "3.9.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 homepage = "https://astar.network/"
@@ -45,9 +45,10 @@ std = [
 	"pallet-session/std",
 	"pallet-timestamp/std",
 	"sp-staking/std",
+	"frame-benchmarking?/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking",
+	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -34,6 +34,7 @@
 //! - `maintenance_mode` - enables or disables pallet maintenance mode
 //! - `set_reward_destination` - sets reward destination for the staker rewards
 //! - `set_contract_stake_info` - root-only call to set storage value (used for fixing corrupted data)
+//! - `burn_stale_reward` - root-only call to burn unclaimed, stale rewards from unregistered contracts
 //!
 //! User is encouraged to refer to specific function implementations for more comprehensive documentation.
 //!
@@ -122,6 +123,15 @@ impl<AccountId> DAppInfo<AccountId> {
         Self {
             developer,
             state: DAppState::Registered,
+        }
+    }
+
+    /// `true` if dApp has been unregistered, `false` otherwise
+    fn is_unregistered(&self) -> bool {
+        if let DAppState::Unregistered(_) = self.state {
+            true
+        } else {
+            false
         }
     }
 }

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -128,11 +128,7 @@ impl<AccountId> DAppInfo<AccountId> {
 
     /// `true` if dApp has been unregistered, `false` otherwise
     fn is_unregistered(&self) -> bool {
-        if let DAppState::Unregistered(_) = self.state {
-            true
-        } else {
-            false
-        }
+        matches!(self.state, DAppState::Unregistered(_))
     }
 }
 

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -12,7 +12,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, ConstU32, IdentityLookup},
 };
 
 pub(crate) type AccountId = u64;
@@ -32,6 +32,7 @@ pub(crate) const MINIMUM_REMAINING_AMOUNT: Balance = 1;
 pub(crate) const MAX_UNLOCKING_CHUNKS: u32 = 4;
 pub(crate) const UNBONDING_PERIOD: EraIndex = 3;
 pub(crate) const MAX_ERA_STAKE_VALUES: u32 = 8;
+pub(crate) const REWARD_RETENTION_PERIOD: u32 = 2;
 
 // Do note that this needs to at least be 3 for tests to be valid. It can be greater but not smaller.
 pub(crate) const BLOCKS_PER_ERA: BlockNumber = 3;
@@ -142,6 +143,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxUnlockingChunks = MaxUnlockingChunks;
     type UnbondingPeriod = UnbondingPeriod;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type UnregisteredDappRewardRetention = ConstU32<REWARD_RETENTION_PERIOD>;
 }
 
 #[derive(

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -912,7 +912,7 @@ pub mod pallet {
             Ok(().into())
         }
 
-        /// Used to burn unclaimed & stale rewards from unregistered contract
+        /// Used to burn unclaimed & stale rewards from an unregistered contract.
         #[pallet::weight(T::WeightInfo::claim_dapp())]
         pub fn burn_stale_reward(
             origin: OriginFor<T>,

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -912,6 +912,7 @@ pub mod pallet {
             Ok(().into())
         }
 
+        /// Used to burn unclaimed & stale rewards from unregistered contract
         #[pallet::weight(T::WeightInfo::claim_dapp())]
         pub fn burn_stale_reward(
             origin: OriginFor<T>,
@@ -923,6 +924,11 @@ pub mod pallet {
 
             let dapp_info =
                 RegisteredDapps::<T>::get(&contract_id).ok_or(Error::<T>::NotOperatedContract)?;
+            ensure!(
+                dapp_info.is_unregistered(),
+                Error::<T>::NotUnregisteredContract
+            );
+
             let current_era = Self::current_era();
 
             let burn_era_limit =

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -2189,3 +2189,97 @@ fn custom_max_encoded_len() {
         max_staker_info_len as usize
     );
 }
+
+#[test]
+fn burn_stale_reward_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        let start_era = DappsStaking::current_era();
+
+        // Register & stake on contract
+        assert_register(developer, &contract_id);
+        assert_bond_and_stake(staker, &contract_id, 100);
+
+        // Advance enough eras so stale rewards become burnable
+        let eras_advanced = REWARD_RETENTION_PERIOD + 1;
+        advance_to_era(start_era + eras_advanced);
+        assert_unregister(developer, &contract_id);
+
+        assert_burn_stale_reward(&contract_id, start_era);
+    })
+}
+
+#[test]
+fn burn_stale_reward_before_retention_period_finished_fails() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        let start_era = DappsStaking::current_era();
+
+        // Register & stake on contract
+        assert_register(developer, &contract_id);
+        assert_bond_and_stake(staker, &contract_id, 100);
+
+        // Advance enough eras so stale rewards become burnable
+        let eras_advanced = REWARD_RETENTION_PERIOD;
+        advance_to_era(start_era + eras_advanced);
+        assert_unregister(developer, &contract_id);
+
+        // Rewards shouldn't be burnable since retention period hasn't expired yet
+        assert_noop!(
+            DappsStaking::burn_stale_reward(RuntimeOrigin::root(), contract_id, start_era,),
+            Error::<TestRuntime>::EraOutOfBounds
+        );
+    })
+}
+
+#[test]
+fn burn_stale_reward_negative_checks() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let developer = 1;
+        let staker = 3;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // Cannot burn from non-existing contract
+        assert_noop!(
+            DappsStaking::burn_stale_reward(RuntimeOrigin::root(), contract_id, 1,),
+            Error::<TestRuntime>::NotOperatedContract
+        );
+
+        // Cannot burn unless called with root privileges
+        assert_noop!(
+            DappsStaking::burn_stale_reward(RuntimeOrigin::signed(developer), contract_id, 1,),
+            BadOrigin
+        );
+
+        // Register & stake on contract
+        assert_register(developer, &contract_id);
+        assert_bond_and_stake(staker, &contract_id, 100);
+
+        // Advance enough eras so stale rewards become burnable
+        let start_era = DappsStaking::current_era();
+        let eras_advanced = REWARD_RETENTION_PERIOD + 2;
+        advance_to_era(start_era + eras_advanced);
+        assert_unregister(developer, &contract_id);
+
+        // Claim them (before they are burned)
+        assert_claim_dapp(&contract_id, start_era);
+
+        // No longer possible to burn if reward was claimed
+        assert_noop!(
+            DappsStaking::burn_stale_reward(RuntimeOrigin::root(), contract_id, start_era,),
+            Error::<TestRuntime>::AlreadyClaimedInThisEra
+        );
+    })
+}

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-precompile-dapps-staking"
-version = "3.6.2"
+version = "3.6.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -16,7 +16,7 @@ use sp_core::{H160, H256};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, IdentityLookup},
+    traits::{BlakeTwo256, ConstU32, IdentityLookup},
     AccountId32,
 };
 extern crate alloc;
@@ -276,6 +276,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxUnlockingChunks = MaxUnlockingChunks;
     type UnbondingPeriod = UnbondingPeriod;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type UnregisteredDappRewardRetention = ConstU32<2>;
 }
 
 pub struct ExternalityBuilder {


### PR DESCRIPTION
**Pull Request Summary**

This is in response to request made by **ShidenDAO** to support burning of _stale_ developer rewards.

In case developer's contract gets unregistered, they can still claim their old rewards.
Before this update, this was possible indefinitely, and some devs would never do this.

With this update, a new extrinsic call is introduced which will burn unregistered contract's unclaimed rewards.

**Summary:**
* the call needs to be made with `root` privileges
* in case contract is still registered, the call will fail
* in case reward was already claimed, it cannot be burned
* once burned, reward cannot be claimed
* the burn is executed per era (same as rewards are claimed)
  * in case multiple eras need burning, multiple calls will be required (e.g. via batch call)


**Check list**
- [x] added unit tests
- [x] updated documentation
