### PR TITLE
Workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,12 @@ num_enum = { version = "0.5.3" }
 slices = "0.2.0"
 derive_more = { version = "0.99" }
 sha3 = "0.10.1"
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0" }
+similar-asserts = { version = "1.1.0" }
+
+evm = { version = "0.37.0" }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 scale-info = { version = "2.3.0", default-features = false }
@@ -91,8 +97,13 @@ pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polka
 # Local deps
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }
 pallet-xvm = { path = "./frame/pallet-xvm", default-features = false }
+pallet-xcm = { path = "./frame/pallet-xcm", default-features = false }
+pallet-xc-asset-config = { path = "./frame/xc-asset-config", default-features = false }
 
 dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
 
+pallet-evm-precompile-assets-erc20 = { path = "./precompiles/assets-erc20" }
+
 precompile-utils = { path = "./precompiles/utils", default-features = false }
+precompile-utils-macro = { path = "./precompiles/utils/macro" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ similar-asserts = { version = "1.1.0" }
 environmental = { version = "1.1.2" }
 futures = { version = "0.3.1" }
 rlp = "0.5"
+tokio = { version = "1.10" }
+tracing = "0.1.34"
 
 # Encoding
 serde = { version = "1.0.136" }
@@ -90,6 +92,11 @@ sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
 
@@ -114,8 +121,11 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "releas
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
 
+fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+fc-db = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
 
@@ -127,6 +137,8 @@ moonbeam-client-evm-tracing = { path = "./vendor/evm-tracing" }
 moonbeam-rpc-core-types = { path = "./vendor/rpc-core/types" }
 moonbeam-rpc-core-txpool = { path = "./vendor/rpc-core/txpool" }
 moonbeam-rpc-primitives-txpool = { path = "./vendor/primitives/txpool" }
+moonbeam-rpc-core-trace = { path = "./vendor/rpc-core/trace" }
+moonbeam-rpc-core-debug = { path = "./vendor/rpc-core/debug" }
 
 # Local deps
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 members = [
 	"chain-extensions/dapps-staking",
-	# "chain-extensions/rmrk",
 	"chain-extensions/xvm",
 	"chain-extensions/types/*",
 	"frame/block-reward",
@@ -26,3 +25,40 @@ members = [
 	"vendor/rpc/txpool",
 	"vendor/runtime/evm_tracer",
 ]
+
+[workspace.package]
+authors = ["Stake Technologies <devops@stake.co.jp>"]
+edition = "2021"
+homepage = "https://astar.network"
+repository = "https://github.com/AstarNetwork/astar-frame"
+
+[workspace.dependencies]
+# General deps
+log = "0.4.16"
+num-traits = { version = "0.2", default-features = false }
+serde = { version = "1.0.136" }
+
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+scale-info = { version = "2.3.0", default-features = false }
+
+# Substrate
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+
+frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
+
+# Extern pallets
+pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+
+# Local deps
+dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
+pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }
+pallet-xvm = { path = "./frame/pallet-xvm", default-features = false }
+xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 # General deps
 log = "0.4.16"
 num-traits = { version = "0.2", default-features = false }
-rand = { version = "0.8.5" }
 assert_matches = "1.3.0"
 hex-literal = "0.3.4"
 hex = { version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,15 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 log = "0.4.16"
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.136" }
+rand = { version = "0.8.5" }
+assert_matches = "1.3.0"
+hex-literal = "0.3.4"
+libsecp256k1 = "0.7.0"
+impl-trait-for-tuples = "0.2"
+num_enum = { version = "0.5.3" }
+slices = "0.2.0"
+derive_more = { version = "0.99" }
+sha3 = "0.10.1"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 scale-info = { version = "2.3.0", default-features = false }
@@ -48,17 +57,42 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
 
-# Extern pallets
+# Substrate pallets
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+
+# Polkadot
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+
+# Frontier
+fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
+
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
 
 # Local deps
-dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }
 pallet-xvm = { path = "./frame/pallet-xvm", default-features = false }
+
+dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
+
+precompile-utils = { path = "./precompiles/utils", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,45 +34,54 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 
 [workspace.dependencies]
 # General deps
-log = "0.4.16"
+# (runtime)
+environmental = { version = "1.1.2", default-features = false }
+sha3 = { version = "0.10.1", default-features = false }
+num_enum = { version = "0.5.3", default-features = false }
+log = { version = "0.4.16", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-assert_matches = "1.3.0"
-hex-literal = "0.3.4"
-hex = { version = "0.4" }
-libsecp256k1 = "0.7.0"
-impl-trait-for-tuples = "0.2"
-num_enum = { version = "0.5.3" }
-slices = "0.2.0"
-derive_more = { version = "0.99" }
-sha3 = "0.10.1"
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0" }
-similar-asserts = { version = "1.1.0" }
-environmental = { version = "1.1.2" }
+rand = { version = "0.8.5", default-features = false }
+
+# (client)
 futures = { version = "0.3.1" }
 rlp = "0.5"
 tokio = { version = "1.10" }
 tracing = "0.1.34"
+similar-asserts = { version = "1.1.0" }
+assert_matches = "1.3.0"
+hex-literal = "0.3.4"
+hex = { version = "0.4", features = ["serde"] }
+libsecp256k1 = "0.7.0"
+impl-trait-for-tuples = "0.2.2"
+slices = "0.2.0"
+derive_more = { version = "0.99" }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0" }
 
 # Encoding
-serde = { version = "1.0.136" }
+# (runtime)
+parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+
+# (client)
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0" }
 
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-scale-info = { version = "2.3.0", default-features = false }
-
 # EVM & Ethereum
-evm = { version = "0.37.0" }
-ethereum-types = { version = "0.14" }
-ethereum = { version = "0.14.0" }
-evm-gasometer = { version = "0.37.0" }
-evm-runtime = { version = "0.37.0" }
+# (runtime)
+evm = { version = "0.37.0", default-features = false }
+ethereum-types = { version = "0.14", default-features = false }
+ethereum = { version = "0.14.0", default-features = false }
+evm-gasometer = { version = "0.37.0", default-features = false }
+evm-runtime = { version = "0.37.0", default-features = false }
 
 # jsonrpsee
-jsonrpsee = { version = "0.16.2" }
+# (runtime)
+jsonrpsee = { version = "0.16.2", default-features = false }
 
 # Substrate
+# (runtime)
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -80,14 +89,16 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 
+# (client)
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
@@ -97,9 +108,8 @@ sc-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
-
 # Substrate pallets
+# (runtime)
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -110,36 +120,29 @@ pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 
 # Polkadot
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+# (runtime)
+xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+
+# (client)
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
-
 # Frontier
+# (runtime)
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
 
+# (client)
 fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-db = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
-
-# Moonbeam EVM Tracing
-evm-tracing-events = { path = "./vendor/primitives/evm-tracing-events" }
-moonbeam-rpc-primitives-debug = { path = "./vendor/primitives/debug" }
-moonbeam-primitives-ext = { path = "./vendor/runtime/ext" }
-moonbeam-client-evm-tracing = { path = "./vendor/evm-tracing" }
-moonbeam-rpc-core-types = { path = "./vendor/rpc-core/types" }
-moonbeam-rpc-core-txpool = { path = "./vendor/rpc-core/txpool" }
-moonbeam-rpc-primitives-txpool = { path = "./vendor/primitives/txpool" }
-moonbeam-rpc-core-trace = { path = "./vendor/rpc-core/trace" }
-moonbeam-rpc-core-debug = { path = "./vendor/rpc-core/debug" }
-
 # Local deps
+# (runtime)
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }
 pallet-xvm = { path = "./frame/pallet-xvm", default-features = false }
 pallet-xcm = { path = "./frame/pallet-xcm", default-features = false }
@@ -148,7 +151,19 @@ pallet-xc-asset-config = { path = "./frame/xc-asset-config", default-features = 
 dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
 
-pallet-evm-precompile-assets-erc20 = { path = "./precompiles/assets-erc20" }
-
+pallet-evm-precompile-assets-erc20 = { path = "./precompiles/assets-erc20", default-features = false }
 precompile-utils = { path = "./precompiles/utils", default-features = false }
-precompile-utils-macro = { path = "./precompiles/utils/macro" }
+
+# Moonbeam EVM Tracing
+# (runtime)
+evm-tracing-events = { path = "./vendor/primitives/evm-tracing-events", default-features = false }
+moonbeam-primitives-ext = { path = "./vendor/runtime/ext", default-features = false }
+
+# (client)
+moonbeam-rpc-primitives-txpool = { path = "./vendor/primitives/txpool" }
+moonbeam-rpc-primitives-debug = { path = "./vendor/primitives/debug" }
+moonbeam-client-evm-tracing = { path = "./vendor/evm-tracing" }
+moonbeam-rpc-core-types = { path = "./vendor/rpc-core/types" }
+moonbeam-rpc-core-txpool = { path = "./vendor/rpc-core/txpool" }
+moonbeam-rpc-core-trace = { path = "./vendor/rpc-core/trace" }
+moonbeam-rpc-core-debug = { path = "./vendor/rpc-core/debug" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,10 +36,10 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 # General deps
 log = "0.4.16"
 num-traits = { version = "0.2", default-features = false }
-serde = { version = "1.0.136" }
 rand = { version = "0.8.5" }
 assert_matches = "1.3.0"
 hex-literal = "0.3.4"
+hex = { version = "0.4" }
 libsecp256k1 = "0.7.0"
 impl-trait-for-tuples = "0.2"
 num_enum = { version = "0.5.3" }
@@ -50,11 +50,26 @@ proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0" }
 similar-asserts = { version = "1.1.0" }
+environmental = { version = "1.1.2" }
+futures = { version = "0.3.1" }
+rlp = "0.5"
 
-evm = { version = "0.37.0" }
+# Encoding
+serde = { version = "1.0.136" }
+serde_json = { version = "1.0" }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 scale-info = { version = "2.3.0", default-features = false }
+
+# EVM & Ethereum
+evm = { version = "0.37.0" }
+ethereum-types = { version = "0.14" }
+ethereum = { version = "0.14.0" }
+evm-gasometer = { version = "0.37.0" }
+evm-runtime = { version = "0.37.0" }
+
+# jsonrpsee
+jsonrpsee = { version = "0.16.2" }
 
 # Substrate
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -68,6 +83,13 @@ sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = 
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false }
 
@@ -92,7 +114,19 @@ xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "releas
 # Frontier
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
 
+fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+
+# Moonbeam EVM Tracing
+evm-tracing-events = { path = "./vendor/primitives/evm-tracing-events" }
+moonbeam-rpc-primitives-debug = { path = "./vendor/primitives/debug" }
+moonbeam-primitives-ext = { path = "./vendor/runtime/ext" }
+moonbeam-client-evm-tracing = { path = "./vendor/evm-tracing" }
+moonbeam-rpc-core-types = { path = "./vendor/rpc-core/types" }
+moonbeam-rpc-core-txpool = { path = "./vendor/rpc-core/txpool" }
+moonbeam-rpc-primitives-txpool = { path = "./vendor/primitives/txpool" }
 
 # Local deps
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ pallet-xc-asset-config = { path = "./frame/xc-asset-config", default-features = 
 
 dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
+assets-chain-extension-types = { path = "./chain-extensions/types/assets", default-features = false }
 
 pallet-evm-precompile-assets-erc20 = { path = "./precompiles/assets-erc20", default-features = false }
 precompile-utils = { path = "./precompiles/utils", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 
 [workspace.dependencies]
 # General deps
-# (runtime)
+# (wasm)
 environmental = { version = "1.1.2", default-features = false }
 sha3 = { version = "0.10.1", default-features = false }
 num_enum = { version = "0.5.3", default-features = false }
@@ -42,7 +42,7 @@ log = { version = "0.4.16", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 
-# (client)
+# (native)
 futures = { version = "0.3.1" }
 rlp = "0.5"
 tokio = { version = "1.10" }
@@ -60,16 +60,16 @@ quote = "1.0"
 syn = { version = "1.0" }
 
 # Encoding
-# (runtime)
+# (wasm)
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 
-# (client)
+# (native)
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0" }
 
 # EVM & Ethereum
-# (runtime)
+# (wasm)
 evm = { version = "0.37.0", default-features = false }
 ethereum-types = { version = "0.14", default-features = false }
 ethereum = { version = "0.14.0", default-features = false }
@@ -77,11 +77,11 @@ evm-gasometer = { version = "0.37.0", default-features = false }
 evm-runtime = { version = "0.37.0", default-features = false }
 
 # jsonrpsee
-# (runtime)
+# (wasm)
 jsonrpsee = { version = "0.16.2", default-features = false }
 
 # Substrate
-# (runtime)
+# (wasm)
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -96,7 +96,7 @@ frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', bran
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 
-# (client)
+# (native)
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
@@ -109,7 +109,7 @@ sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 # Substrate pallets
-# (runtime)
+# (wasm)
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
@@ -120,21 +120,21 @@ pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polka
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 
 # Polkadot
-# (runtime)
+# (wasm)
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
 
-# (client)
+# (native)
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
 
 # Frontier
-# (runtime)
+# (wasm)
 fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
 pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
 
-# (client)
+# (native)
 fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
@@ -142,7 +142,7 @@ fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "pol
 fc-db = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
 
 # Local deps
-# (runtime)
+# (wasm)
 pallet-dapps-staking = { path = "./frame/dapps-staking", default-features = false }
 pallet-xvm = { path = "./frame/pallet-xvm", default-features = false }
 pallet-xcm = { path = "./frame/pallet-xcm", default-features = false }
@@ -155,11 +155,11 @@ pallet-evm-precompile-assets-erc20 = { path = "./precompiles/assets-erc20", defa
 precompile-utils = { path = "./precompiles/utils", default-features = false }
 
 # Moonbeam EVM Tracing
-# (runtime)
+# (wasm)
 evm-tracing-events = { path = "./vendor/primitives/evm-tracing-events", default-features = false }
 moonbeam-primitives-ext = { path = "./vendor/runtime/ext", default-features = false }
 
-# (client)
+# (native)
 moonbeam-rpc-primitives-txpool = { path = "./vendor/primitives/txpool" }
 moonbeam-rpc-primitives-debug = { path = "./vendor/primitives/debug" }
 moonbeam-client-evm-tracing = { path = "./vendor/evm-tracing" }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Since both `pallet-dapps-staking` and `pallet-precompile-dapps-staking` are tigh
 
 When creating tags, it is sufficient to just create a single tag for `pallet-dapps-staking` and reuse it for the precompiles in `Astar` repo.
 
+## Workspace Dependency Handling
+
+All dependencies should be listed inside the workspace's root `Cargo.toml` file.
+This allows us to easily change version of a crate used by the entire repo by modifying the version in a single place.
+
+Right now, if **non_std** is required, `default-features = false` must be set in the root `Cargo.toml` file (related to this [issue](https://github.com/rust-lang/cargo/pull/11409)). Otherwise, it will have no effect, causing your compilation to fail.
+Also `package` imports aren't properly propagated from root to sub-crates, so defining those should be avoided.
+
+Defining _features_ in the root `Cargo.toml` is additive with the features defined in concrete crate's `Cargo.toml`.
+
+**Adding Dependency**
+1. Check if the dependency is already defined in the root `Cargo.toml`
+    1. if **yes**, nothing to do, just take note of the enabled features
+    2. if **no**, add it (make sure to use `default-features = false` if dependency is used in _no_std_ context)
+2. Add `new_dependecy = { workspace = true }` to the required crate
+3. In case dependency is defined with `default-features = false` but you need it in _std_ context, add `features = ["std"]` to the required crate.
+
 ## Further Reading
 
 * [Official Documentation](https://docs.astar.network/)

--- a/chain-extensions/dapps-staking/Cargo.toml
+++ b/chain-extensions/dapps-staking/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "pallet-chain-extension-dapps-staking"
 version = "1.1.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "dApps Staking chain extension for WASM contracts"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-log = "0.4.16"
-num-traits = { version = "0.2", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Astar
-dapps-staking-chain-extension-types = { path = "../types/dapps-staking", default-features = false }
-pallet-dapps-staking = { path = "../../frame/dapps-staking", default-features = false }
+dapps-staking-chain-extension-types = { workspace = true }
+pallet-dapps-staking = { workspace = true }
 
 [features]
 default = ["std"]

--- a/chain-extensions/dapps-staking/Cargo.toml
+++ b/chain-extensions/dapps-staking/Cargo.toml
@@ -9,14 +9,14 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pallet-contracts = { workspace = true }
 pallet-contracts-primitives = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
@@ -28,7 +28,7 @@ pallet-dapps-staking = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"dapps-staking-chain-extension-types/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/chain-extensions/dapps-staking/src/lib.rs
+++ b/chain-extensions/dapps-staking/src/lib.rs
@@ -22,7 +22,6 @@ use sp_runtime::{
     DispatchError,
 };
 
-use codec::Encode;
 use dapps_staking_chain_extension_types::{
     DSError, DappsStakingAccountInput, DappsStakingEraInput, DappsStakingNominationInput,
     DappsStakingValueInput,
@@ -33,6 +32,7 @@ use pallet_contracts::chain_extension::{
     ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };
 use pallet_dapps_staking::{RewardDestination, WeightInfo};
+use parity_scale_codec::Encode;
 use sp_std::marker::PhantomData;
 
 type BalanceOf<T> = <<T as pallet_dapps_staking::Config>::Currency as Currency<

--- a/chain-extensions/pallet-assets/Cargo.toml
+++ b/chain-extensions/pallet-assets/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
 name = "pallet-chain-extension-assets"
 version = "0.1.0"
-authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Assets chain extension for WASM contracts"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-assets-chain-extension-types = { path = "../types/assets", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-log = "0.4.16"
-num-traits = { version = "0.2", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+assets-chain-extension-types = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"frame-support/std",
 	"frame-system/std",
 	"num-traits/std",

--- a/chain-extensions/pallet-assets/src/lib.rs
+++ b/chain-extensions/pallet-assets/src/lib.rs
@@ -21,7 +21,6 @@
 pub mod weights;
 
 use assets_chain_extension_types::{select_origin, Origin, Outcome};
-use codec::Encode;
 use frame_support::traits::fungibles::InspectMetadata;
 use frame_support::traits::tokens::fungibles::approvals::Inspect;
 use frame_system::RawOrigin;
@@ -29,6 +28,7 @@ use pallet_assets::WeightInfo;
 use pallet_contracts::chain_extension::{
     ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };
+use parity_scale_codec::Encode;
 use sp_runtime::traits::StaticLookup;
 use sp_runtime::DispatchError;
 use sp_std::marker::PhantomData;

--- a/chain-extensions/types/assets/Cargo.toml
+++ b/chain-extensions/types/assets/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "assets-chain-extension-types"
 version = "0.1.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
-description = "Types definitions forassets chain-extension"
+description = "Types definitions for assets chain-extension"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+frame-system = { workspace = true }
+pallet-contracts = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"scale-info/std",
-	"scale/std",
+	"parity-scale-codec/std",
 	"pallet-contracts/std",
 	"sp-runtime/std",
 	"frame-system/std",

--- a/chain-extensions/types/assets/src/lib.rs
+++ b/chain-extensions/types/assets/src/lib.rs
@@ -17,8 +17,8 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-use scale::MaxEncodedLen;
-use scale::{Decode, Encode};
+use parity_scale_codec::MaxEncodedLen;
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{DispatchError, ModuleError};
 
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]

--- a/chain-extensions/types/dapps-staking/Cargo.toml
+++ b/chain-extensions/types/dapps-staking/Cargo.toml
@@ -9,16 +9,16 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
 frame-support = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"frame-support/std",
 	"scale-info/std",
 	"sp-core/std",

--- a/chain-extensions/types/dapps-staking/Cargo.toml
+++ b/chain-extensions/types/dapps-staking/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "dapps-staking-chain-extension-types"
 version = "1.1.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Types definitions for dapps-staking chain-extension"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+frame-support = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/chain-extensions/types/dapps-staking/src/lib.rs
+++ b/chain-extensions/types/dapps-staking/src/lib.rs
@@ -17,8 +17,8 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-use codec::{Decode, Encode};
 use frame_support::pallet_prelude::MaxEncodedLen;
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{DispatchError, ModuleError};
 
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]

--- a/chain-extensions/types/xvm/Cargo.toml
+++ b/chain-extensions/types/xvm/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "xvm-chain-extension-types"
 version = "0.1.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Types definitions for contracts using xvm chain-extension."
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
+scale-info = { workspace = true, features = ["derive"] }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/chain-extensions/types/xvm/Cargo.toml
+++ b/chain-extensions/types/xvm/Cargo.toml
@@ -9,15 +9,15 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
-scale-info = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/chain-extensions/types/xvm/src/lib.rs
+++ b/chain-extensions/types/xvm/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{DispatchError, ModuleError};
 use sp_std::vec::Vec;
 

--- a/chain-extensions/xvm/Cargo.toml
+++ b/chain-extensions/xvm/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "pallet-chain-extension-xvm"
 version = "0.1.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "Chain extension for XVM"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-log = "0.4.16"
-num-traits = { version = "0.2", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Astar
-pallet-xvm = { path = "../../frame/pallet-xvm", default-features = false }
-xvm-chain-extension-types = { path = "../types/xvm", default-features = false }
+pallet-xvm = { workspace = true }
+xvm-chain-extension-types = { workspace = true }
 
 [features]
 default = ["std"]

--- a/chain-extensions/xvm/Cargo.toml
+++ b/chain-extensions/xvm/Cargo.toml
@@ -9,14 +9,14 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
 pallet-contracts = { workspace = true }
 pallet-contracts-primitives = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
@@ -28,7 +28,7 @@ xvm-chain-extension-types = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"frame-support/std",
 	"frame-system/std",
 	"num-traits/std",

--- a/frame/block-reward/Cargo.toml
+++ b/frame/block-reward/Cargo.toml
@@ -9,24 +9,27 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
+serde = { workspace = true }
+
 frame-support = { workspace = true }
 frame-system = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
+scale-info = { workspace = true }
 sp-arithmetic = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 frame-benchmarking = { workspace = true, optional = true }
-pallet-balances = { workspace = true, optional = true }
-pallet-timestamp = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-sp-core = { workspace = true, optional = true }
+
+[dev-dependencies]
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"sp-core/std",
 	"scale-info/std",
 	"sp-std/std",
@@ -41,6 +44,5 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
-	"sp-core",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/block-reward/Cargo.toml
+++ b/frame/block-reward/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "pallet-block-reward"
 version = "2.2.2"
-authors = ["Stake  Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/Astar"
 description = "FRAME pallet for managing block reward issuance & distribution"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+sp-arithmetic = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false, optional = true }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-serde = { version = "1.0.136", optional = true }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+frame-benchmarking = { workspace = true, optional = true }
+pallet-balances = { workspace = true, optional = true }
+pallet-timestamp = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+sp-core = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -41,5 +41,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"sp-core",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/collator-selection/Cargo.toml
+++ b/frame/collator-selection/Cargo.toml
@@ -1,43 +1,43 @@
 [package]
-authors = ["Anonymous"]
 description = "Simple staking pallet with a fixed stake."
-edition = "2021"
-homepage = "https://substrate.io"
 license = "Apache-2.0"
 name = "pallet-collator-selection"
 readme = "README.md"
-repository = "https://github.com/paritytech/cumulus/"
 version = "3.3.2"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { default-features = false, features = ["derive"], package = "parity-scale-codec", version = "3.0.0" }
-log = { version = "0.4.16", default-features = false }
-rand = { version = "0.8.5", features = ["std_rng"], default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.132", default-features = false }
+codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
+log = { workspace = true, default-features = false }
+rand = { workspace = true, features = ["std_rng"], default-features = false }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-session = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-std = { workspace = true }
 
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
-pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-tracing = { workspace = true }
 
 [features]
 default = ["std"]
@@ -59,6 +59,8 @@ std = [
 	"frame-benchmarking/std",
 	"pallet-authorship/std",
 	"pallet-session/std",
+	"pallet-aura/std",
+	"pallet-balances/std",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/collator-selection/Cargo.toml
+++ b/frame/collator-selection/Cargo.toml
@@ -15,29 +15,29 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
 log = { workspace = true, default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.132", default-features = false }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 
-frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-authorship = { workspace = true }
+pallet-session = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-std = { workspace = true }
 
-frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-benchmarking = { workspace = true, optional = true }
 rand = { version = "0.8.5", features = ["std_rng"], default-features = false, optional = true }
 
 [dev-dependencies]
-pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-aura = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-consensus-aura = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-tracing = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/collator-selection/Cargo.toml
+++ b/frame/collator-selection/Cargo.toml
@@ -15,29 +15,29 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
 log = { workspace = true, default-features = false }
-rand = { workspace = true, features = ["std_rng"], default-features = false }
-scale-info = { workspace = true, features = ["derive"] }
-serde = { workspace = true }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.132", default-features = false }
 
-frame-support = { workspace = true }
-frame-system = { workspace = true }
-pallet-authorship = { workspace = true }
-pallet-session = { workspace = true }
-sp-runtime = { workspace = true }
-sp-staking = { workspace = true }
-sp-std = { workspace = true }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-authorship = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-session = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-staking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
-frame-benchmarking = { workspace = true, optional = true }
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+rand = { version = "0.8.5", features = ["std_rng"], default-features = false, optional = true }
 
 [dev-dependencies]
-pallet-aura = { workspace = true }
-pallet-balances = { workspace = true }
-pallet-timestamp = { workspace = true }
-sp-consensus-aura = { workspace = true }
-sp-core = { workspace = true }
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
-sp-tracing = { workspace = true }
+pallet-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-consensus-aura = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
 
 [features]
 default = ["std"]
@@ -45,12 +45,12 @@ runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
+	"rand",
 ]
 std = [
 	"codec/std",
 	"log/std",
 	"scale-info/std",
-	"rand/std",
 	"sp-runtime/std",
 	"sp-staking/std",
 	"sp-std/std",

--- a/frame/collator-selection/Cargo.toml
+++ b/frame/collator-selection/Cargo.toml
@@ -13,9 +13,10 @@ repository.workspace = true
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { workspace = true, features = ["derive"], package = "parity-scale-codec" }
-log = { workspace = true, default-features = false }
-scale-info = { workspace = true, features = ["derive"] }
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
+rand = { workspace = true, features = ["std_rng"] }
+scale-info = { workspace = true }
 serde = { workspace = true }
 
 frame-support = { workspace = true }
@@ -27,7 +28,6 @@ sp-staking = { workspace = true }
 sp-std = { workspace = true }
 
 frame-benchmarking = { workspace = true, optional = true }
-rand = { version = "0.8.5", features = ["std_rng"], default-features = false, optional = true }
 
 [dev-dependencies]
 pallet-aura = { workspace = true }
@@ -36,21 +36,20 @@ pallet-timestamp = { workspace = true }
 sp-consensus-aura = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
-sp-runtime = { workspace = true }
 sp-tracing = { workspace = true }
 
 [features]
 default = ["std"]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
+	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"rand",
 ]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"log/std",
 	"scale-info/std",
+	"rand/std",
 	"sp-runtime/std",
 	"sp-staking/std",
 	"sp-std/std",
@@ -60,7 +59,6 @@ std = [
 	"pallet-authorship/std",
 	"pallet-session/std",
 	"pallet-aura/std",
-	"pallet-balances/std",
 ]
 
 try-runtime = ["frame-support/try-runtime"]

--- a/frame/contracts-migration/Cargo.toml
+++ b/frame/contracts-migration/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "pallet-contracts-migration"
 version = "1.0.0"
-authors = ["Stake  Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/Astar"
 description = "FRAME pallet for managing multi-block pallet contracts storage migration"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-contracts = { workspace = true }
+scale-info = { workspace = true }
+sp-arithmetic = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/contracts-migration/Cargo.toml
+++ b/frame/contracts-migration/Cargo.toml
@@ -9,21 +9,19 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-contracts = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-arithmetic = { workspace = true }
-sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
-	"sp-core/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-std/std",
 	"frame-support/std",

--- a/frame/contracts-migration/src/lib.rs
+++ b/frame/contracts-migration/src/lib.rs
@@ -31,9 +31,9 @@ use frame_support::{
     WeakBoundedVec,
 };
 
-use codec::{Decode, Encode, FullCodec};
 use frame_system::pallet_prelude::*;
 use pallet_contracts::Determinism;
+use parity_scale_codec::{Decode, Encode, FullCodec};
 use sp_runtime::Saturating;
 #[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;

--- a/frame/custom-signatures/Cargo.toml
+++ b/frame/custom-signatures/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "pallet-custom-signatures"
 version = "4.6.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network/"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "FRAME pallet for user defined extrinsic signatures"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.140", features = ["derive"], optional = true }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, features = ["derive"], optional = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [dev-dependencies]
-assert_matches = "1.3.0"
-hex-literal = "0.3.4"
-libsecp256k1 = "0.7.0"
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+assert_matches = { workspace = true }
+hex-literal = { workspace = true }
+libsecp256k1 = { workspace = true }
+pallet-balances = { workspace = true }
+sp-core = { workspace = true }
+sp-keyring = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/custom-signatures/Cargo.toml
+++ b/frame/custom-signatures/Cargo.toml
@@ -9,11 +9,11 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
@@ -24,14 +24,13 @@ assert_matches = { workspace = true }
 hex-literal = { workspace = true }
 libsecp256k1 = { workspace = true }
 pallet-balances = { workspace = true }
-sp-core = { workspace = true }
 sp-keyring = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"serde",
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-io/std",
 	"sp-std/std",

--- a/frame/custom-signatures/src/ethereum.rs
+++ b/frame/custom-signatures/src/ethereum.rs
@@ -17,7 +17,7 @@
 
 //! Ethereum prefixed signatures compatibility instances.
 
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 use sp_core::ecdsa;
 use sp_io::{crypto::secp256k1_ecdsa_recover_compressed, hashing::keccak_256};
 use sp_runtime::traits::{IdentifyAccount, Lazy, Verify};

--- a/frame/custom-signatures/src/tests.rs
+++ b/frame/custom-signatures/src/tests.rs
@@ -14,13 +14,13 @@
 
 use crate as custom_signatures;
 use assert_matches::assert_matches;
-use codec::Encode;
 use custom_signatures::*;
 use frame_support::{
     traits::Contains,
     {assert_err, assert_ok, parameter_types},
 };
 use hex_literal::hex;
+use parity_scale_codec::Encode;
 use sp_core::{ecdsa, Pair};
 use sp_io::{hashing::keccak_256, TestExternalities};
 use sp_keyring::AccountKeyring as Keyring;

--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -9,15 +9,13 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 num-traits = { workspace = true }
-pallet-balances = { workspace = true }
-pallet-session = { workspace = true }
-pallet-timestamp = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
-serde = { workspace = true, features = ["derive"], optional = true }
+parity-scale-codec = { workspace = true }
+
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 sp-arithmetic = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
@@ -27,11 +25,16 @@ sp-std = { workspace = true }
 
 frame-benchmarking = { workspace = true, optional = true }
 
+[dev-dependencies]
+pallet-balances = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+
 [features]
 default = ["std"]
 std = [
 	"serde",
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"num-traits/std",
 	"sp-core/std",
@@ -48,7 +51,7 @@ std = [
 	"frame-benchmarking?/std",
 ]
 runtime-benchmarks = [
-	"frame-benchmarking/runtime-benchmarks",
+	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",

--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
 name = "pallet-dapps-staking"
 version = "3.9.0"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
-homepage = "https://astar.network/"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "FRAME pallet to staking for dapps"
 license = "PolyForm-Noncommercial-1.0.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["derive"], default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-num-traits = { version = "0.2", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.140", features = ["derive"], optional = true }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-staking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+num-traits = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true, features = ["derive"], optional = true }
+sp-arithmetic = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-std = { workspace = true }
 
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.37', default-features = false, optional = true }
+frame-benchmarking = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/frame/dapps-staking/src/lib.rs
+++ b/frame/dapps-staking/src/lib.rs
@@ -56,9 +56,9 @@
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode, HasCompact, MaxEncodedLen};
 use frame_support::traits::Currency;
 use frame_system::{self as system};
+use parity_scale_codec::{Decode, Encode, HasCompact, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{AtLeast32BitUnsigned, Zero},
@@ -268,7 +268,7 @@ pub struct StakerInfo<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> {
 impl<Balance: AtLeast32BitUnsigned + Copy + MaxEncodedLen> MaxEncodedLen for StakerInfo<Balance> {
     // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
     fn max_encoded_len() -> usize {
-        codec::Compact(MAX_ASSUMED_VEC_LEN)
+        parity_scale_codec::Compact(MAX_ASSUMED_VEC_LEN)
             .encoded_size()
             .saturating_add(
                 (MAX_ASSUMED_VEC_LEN as usize)
@@ -459,7 +459,7 @@ impl<Balance: AtLeast32BitUnsigned + Default + Copy + MaxEncodedLen> MaxEncodedL
 {
     // This is just an assumption, will be calculated properly in the future. See the comment for `MAX_ASSUMED_VEC_LEN`.
     fn max_encoded_len() -> usize {
-        codec::Compact(MAX_ASSUMED_VEC_LEN)
+        parity_scale_codec::Compact(MAX_ASSUMED_VEC_LEN)
             .encoded_size()
             .saturating_add(
                 (MAX_ASSUMED_VEC_LEN as usize)

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -16,7 +16,7 @@ use frame_support::{
 };
 use sp_core::{H160, H256};
 
-use codec::{Decode, Encode, MaxEncodedLen};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,

--- a/frame/pallet-xcm/Cargo.toml
+++ b/frame/pallet-xcm/Cargo.toml
@@ -5,26 +5,26 @@ name = "pallet-xcm"
 version = "0.9.28"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-log = { version = "0.4.16", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.140", optional = true, features = ["derive"] }
+codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+log = { workspace = true, default-features = false }
+scale-info = { workspace = true, features = ["derive"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.37" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.37" }
+xcm = { workspace = true }
+xcm-executor = { workspace = true }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
-polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+pallet-balances = { workspace = true }
+polkadot-parachain = { workspace = true }
+polkadot-runtime-parachains = { workspace = true }
+sp-io = { workspace = true }
+xcm-builder = { workspace = true }
 
 [features]
 default = ["std"]

--- a/frame/pallet-xcm/Cargo.toml
+++ b/frame/pallet-xcm/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
-authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2021"
+authors = ["Parity Technologies <admin@parity.io>", "Stake Technologies <devops@stake.co.jp>"]
 name = "pallet-xcm"
 version = "0.9.28"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
-log = { workspace = true, default-features = false }
-scale-info = { workspace = true, features = ["derive"] }
-serde = { workspace = true, optional = true, features = ["derive"] }
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true, optional = true }
 
 frame-support = { workspace = true }
 frame-system = { workspace = true }
@@ -29,7 +31,7 @@ xcm-builder = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde",
 	"sp-std/std",

--- a/frame/pallet-xcm/src/lib.rs
+++ b/frame/pallet-xcm/src/lib.rs
@@ -27,8 +27,8 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-use codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
 use frame_support::traits::{Contains, EnsureOrigin, Get, OriginTrait};
+use parity_scale_codec::{Decode, Encode, EncodeLike, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{BadOrigin, Saturating},

--- a/frame/pallet-xcm/src/tests.rs
+++ b/frame/pallet-xcm/src/tests.rs
@@ -838,7 +838,7 @@ fn trapped_assets_can_be_claimed() {
 
 #[test]
 fn fake_latest_versioned_multilocation_works() {
-    use codec::Encode;
+    use parity_scale_codec::Encode;
     let remote = Parachain(1000).into();
     let versioned_remote = LatestVersionedMultiLocation(&remote);
     assert_eq!(

--- a/frame/pallet-xvm/Cargo.toml
+++ b/frame/pallet-xvm/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "pallet-xvm"
-authors = ["Stake Technologies"]
-edition = "2021"
 version = "0.2.1"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-impl-trait-for-tuples = "0.2"
-log = { version = "0.4", default-features = false }
-serde = { version = "1.0.106", optional = true }
+impl-trait-for-tuples = { workspace = true }
+log = { workspace = true, default-features = false }
+serde = { workspace = true, optional = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true, default-features = false }
+frame-benchmarking = { workspace = true, optional = true }
 
 # EVM support 
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, optional = true, features = ["forbid-evm-reentrancy"] }
+pallet-evm = { workspace = true, optional = true }
 
 # Substrate WASM VM support
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false, optional = true }
-
-[dev-dependencies]
+pallet-contracts = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/frame/pallet-xvm/Cargo.toml
+++ b/frame/pallet-xvm/Cargo.toml
@@ -8,14 +8,14 @@ repository.workspace = true
 
 [dependencies]
 impl-trait-for-tuples = { workspace = true }
-log = { workspace = true, default-features = false }
+log = { workspace = true }
 serde = { workspace = true, optional = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
@@ -29,6 +29,8 @@ pallet-evm = { workspace = true, optional = true }
 # Substrate WASM VM support
 pallet-contracts = { workspace = true, optional = true }
 
+[dev-dependencies]
+
 [features]
 default = ["std"]
 evm = [
@@ -38,7 +40,7 @@ wasm = [
 	"pallet-contracts",
 ]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-contracts/std",

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -31,8 +31,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
 use frame_support::weights::Weight;
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{traits::Member, RuntimeDebug};
 use sp_std::prelude::*;
 

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -19,8 +19,8 @@
 //! WASM (substrate contracts) support for XVM pallet.
 
 use crate::*;
-use codec::HasCompact;
 use frame_support::traits::Currency;
+use parity_scale_codec::HasCompact;
 use scale_info::TypeInfo;
 use sp_runtime::traits::Get;
 use sp_std::fmt::Debug;

--- a/frame/xc-asset-config/Cargo.toml
+++ b/frame/xc-asset-config/Cargo.toml
@@ -15,7 +15,7 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 

--- a/frame/xc-asset-config/Cargo.toml
+++ b/frame/xc-asset-config/Cargo.toml
@@ -7,15 +7,15 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-log = { workspace = true, default-features = false }
+log = { workspace = true }
 serde = { workspace = true, optional = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
-scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-io = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
@@ -35,7 +35,7 @@ default = ["std"]
 std = [
 	"frame-support/std",
 	"frame-system/std",
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde",
 	"sp-io/std",

--- a/frame/xc-asset-config/Cargo.toml
+++ b/frame/xc-asset-config/Cargo.toml
@@ -1,39 +1,41 @@
 [package]
 name = "pallet-xc-asset-config"
-authors = ["Stake Technologies"]
-edition = "2021"
 version = "1.3.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = { version = "0.4", default-features = false }
-serde = { version = "1.0.140", optional = true }
+log = { workspace = true, default-features = false }
+serde = { workspace = true, optional = true }
 
 # Substrate
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"] }
+codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 scale-info = { version = "2.0", default-features = false, features = ["derive"] }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Polkadot
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm = { workspace = true }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true, default-features = false }
+frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-core = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
 	"frame-support/std",
 	"frame-system/std",
-	"parity-scale-codec/std",
+	"codec/std",
 	"scale-info/std",
 	"serde",
 	"sp-io/std",

--- a/frame/xc-asset-config/src/lib.rs
+++ b/frame/xc-asset-config/src/lib.rs
@@ -67,9 +67,9 @@ pub use weights::WeightInfo;
 pub mod pallet {
 
     use crate::weights::WeightInfo;
-    use codec::HasCompact;
     use frame_support::{pallet_prelude::*, traits::EnsureOrigin};
     use frame_system::pallet_prelude::*;
+    use parity_scale_codec::HasCompact;
     use sp_std::boxed::Box;
     use xcm::{v1::MultiLocation, VersionedMultiLocation};
 

--- a/frame/xc-asset-config/src/lib.rs
+++ b/frame/xc-asset-config/src/lib.rs
@@ -67,9 +67,9 @@ pub use weights::WeightInfo;
 pub mod pallet {
 
     use crate::weights::WeightInfo;
+    use codec::HasCompact;
     use frame_support::{pallet_prelude::*, traits::EnsureOrigin};
     use frame_system::pallet_prelude::*;
-    use parity_scale_codec::HasCompact;
     use sp_std::boxed::Box;
     use xcm::{v1::MultiLocation, VersionedMultiLocation};
 

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -1,43 +1,45 @@
 [package]
 name = "pallet-evm-precompile-assets-erc20"
-authors = ["Stake Technologies", "PureStake"]
 description = "A Precompile to expose a Assets pallet through an ERC20-compliant interface."
-edition = "2021"
 version = "0.5.2"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-slices = "0.2.0"
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+slices = { workspace = true }
 
-precompile-utils = { path = "../utils", default-features = false }
+precompile-utils = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-balances = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
-serde = { version = "1.0.140" }
-sha3 = "0.10.1"
+derive_more = { workspace = true }
+serde = { workspace = true }
+sha3 = { workspace = true }
 
-precompile-utils = { path = "../utils", features = ["testing"] }
+precompile-utils = { workspace = true }
 
-codec = { package = "parity-scale-codec", version = "3.0.0", features = ["max-encoded-len"] }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+pallet-timestamp = { workspace = true }
+scale-info = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -9,17 +9,17 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
+num_enum = { workspace = true }
 slices = { workspace = true }
 
 precompile-utils = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-assets = { workspace = true }
 pallet-balances = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
@@ -34,17 +34,15 @@ derive_more = { workspace = true }
 serde = { workspace = true }
 sha3 = { workspace = true }
 
-precompile-utils = { workspace = true }
+precompile-utils = { workspace = true, features = ["testing"] }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
 pallet-timestamp = { workspace = true }
 scale-info = { workspace = true }
-sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -37,12 +37,12 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{AsEnsureOriginWithArg, Everything},
     weights::Weight,
 };
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 
 use frame_system::EnsureRoot;
 use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot};

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.3"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
-edition = "2021"
 license = "Apache-2.0"
-homepage = "https://astar.network"
-repository = "https://github.com/AstarNetwork/astar-frame"
 description = "dApps Staking EVM precompiles"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 codec = { workspace = true, package = "parity-scale-codec" }

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -9,33 +9,33 @@ repository = "https://github.com/AstarNetwork/astar-frame"
 description = "dApps Staking EVM precompiles"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-precompile-utils = { path = "../utils", default-features = false }
-scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+precompile-utils = { workspace = true }
+scale-info = { workspace = true, features = ["derive"] }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Astar
-pallet-dapps-staking = { path = "../../frame/dapps-staking", default-features = false }
+pallet-dapps-staking = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
-derive_more = "0.99"
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-precompile-utils = { path = "../utils", features = ["testing"] }
-serde = "1.0.140"
-sha3 = "0.10.1"
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+derive_more = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+precompile-utils = { workspace = true, features = ["testing"] }
+serde = { workspace = true }
+sha3 = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/dapps-staking/Cargo.toml
+++ b/precompiles/dapps-staking/Cargo.toml
@@ -9,19 +9,21 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
+log = { workspace = true }
+num_enum = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+
 frame-support = { workspace = true }
 frame-system = { workspace = true }
-log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
-precompile-utils = { workspace = true }
-scale-info = { workspace = true, features = ["derive"] }
+
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 # Astar
 pallet-dapps-staking = { workspace = true }
+precompile-utils = { workspace = true, default-features = false }
 
 # Frontier
 fp-evm = { workspace = true }
@@ -35,12 +37,11 @@ precompile-utils = { workspace = true, features = ["testing"] }
 serde = { workspace = true }
 sha3 = { workspace = true }
 sp-io = { workspace = true }
-sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"scale-info/std",
 	"sp-std/std",
 	"sp-core/std",

--- a/precompiles/dapps-staking/src/lib.rs
+++ b/precompiles/dapps-staking/src/lib.rs
@@ -21,8 +21,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(test, feature(assert_matches))]
 
-use codec::{Decode, Encode};
 use fp_evm::{PrecompileHandle, PrecompileOutput};
+use parity_scale_codec::{Decode, Encode};
 
 use frame_support::{
     dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -18,7 +18,6 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{Currency, OnFinalize, OnInitialize},
@@ -29,6 +28,7 @@ use pallet_dapps_staking::weights;
 use pallet_evm::{
     AddressMapping, EnsureAddressNever, EnsureAddressRoot, PrecompileResult, PrecompileSet,
 };
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256};
 use sp_io::TestExternalities;

--- a/precompiles/sr25519/Cargo.toml
+++ b/precompiles/sr25519/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
-precompile-utils = { workspace = true }
+num_enum = { workspace = true }
+precompile-utils = { workspace = true, default-features = false }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-std = { workspace = true }
@@ -39,7 +39,7 @@ sp-runtime = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"pallet-evm/std",
 	"precompile-utils/std",

--- a/precompiles/sr25519/Cargo.toml
+++ b/precompiles/sr25519/Cargo.toml
@@ -1,38 +1,40 @@
 [package]
 name = "pallet-evm-precompile-sr25519"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "SR25519 crypto support for EVM."
-edition = "2021"
 version = "1.2.1"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = "0.4.17"
-num_enum = { version = "0.5.3", default-features = false }
-precompile-utils = { path = "../utils", default-features = false }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+precompile-utils = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
-scale-info = "2.0"
-serde = "1.0.140"
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
-precompile-utils = { path = "../utils", features = ["testing"] }
+precompile-utils = { workspace = true, features = ["testing"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/sr25519/src/mock.rs
+++ b/precompiles/sr25519/src/mock.rs
@@ -20,8 +20,8 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 

--- a/precompiles/substrate-ecdsa/Cargo.toml
+++ b/precompiles/substrate-ecdsa/Cargo.toml
@@ -1,38 +1,40 @@
 [package]
 name = "pallet-evm-precompile-substrate-ecdsa"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Substrate ECDSA crypto support for EVM."
-edition = "2021"
 version = "1.2.2"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-precompile-utils = { path = "../utils", default-features = false }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+precompile-utils = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
-scale-info = "2.0"
-serde = "1.0.140"
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
-precompile-utils = { path = "../utils", features = ["testing"] }
+precompile-utils = { workspace = true, features = ["testing"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/substrate-ecdsa/Cargo.toml
+++ b/precompiles/substrate-ecdsa/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
-precompile-utils = { workspace = true }
+num_enum = { workspace = true }
+precompile-utils = { workspace = true, default-features = false }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-std = { workspace = true }
@@ -40,7 +40,7 @@ sp-runtime = { workspace = true }
 default = ["std"]
 std = [
 	"num_enum/std",
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"pallet-evm/std",
 	"precompile-utils/std",

--- a/precompiles/substrate-ecdsa/src/mock.rs
+++ b/precompiles/substrate-ecdsa/src/mock.rs
@@ -20,8 +20,8 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -2,24 +2,26 @@
 name = "precompile-utils"
 authors = ["StakeTechnologies", "PureStake"]
 description = "Utils to write EVM precompiles."
-edition = "2021"
 version = "0.4.3"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 # There's a problem with --all-features when this is moved under dev-deps
-evm = { workspace = true, optional = true }
+evm = { workspace = true, features = ["std"], optional = true }
 impl-trait-for-tuples = { workspace = true }
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
-sha3 = { workspace = true, default-features = false }
+num_enum = { workspace = true }
+sha3 = { workspace = true }
 similar-asserts = { workspace = true, optional = true }
 
-precompile-utils-macro = { workspace = true }
+precompile-utils-macro = { path = "macro" }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+parity-scale-codec = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
@@ -39,7 +41,7 @@ hex-literal = { workspace = true }
 default = ["std"]
 std = [
 	"evm/std",
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -7,33 +7,33 @@ version = "0.4.3"
 
 [dependencies]
 # There's a problem with --all-features when this is moved under dev-deps
-evm = { version = "0.37.0", optional = true }
-impl-trait-for-tuples = "0.2.2"
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-sha3 = { version = "0.10.1", default-features = false }
-similar-asserts = { version = "1.1.0", optional = true }
+evm = { workspace = true, optional = true }
+impl-trait-for-tuples = { workspace = true }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+sha3 = { workspace = true, default-features = false }
+similar-asserts = { workspace = true, optional = true }
 
-precompile-utils-macro = { path = "macro" }
+precompile-utils-macro = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 # Polkadot / XCM
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm = { workspace = true }
 
 [dev-dependencies]
-hex-literal = "0.3.1"
+hex-literal = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -2,8 +2,10 @@
 name = "precompile-utils-macro"
 authors = ["StakeTechnologies", "PureStake"]
 description = ""
-edition = "2018"
 version = "0.1.0"
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [lib]
 proc-macro = true
@@ -13,7 +15,7 @@ name = "tests"
 path = "tests/tests.rs"
 
 [dependencies]
-num_enum = { workspace = true, default-features = false }
+num_enum = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 sha3 = { workspace = true }

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -13,8 +13,8 @@ name = "tests"
 path = "tests/tests.rs"
 
 [dependencies]
-num_enum = { version = "0.5.3", default-features = false }
-proc-macro2 = "1.0"
-quote = "1.0"
-sha3 = "0.8"
-syn = { version = "1.0", features = ["extra-traits", "fold", "full", "visit"] }
+num_enum = { workspace = true, default-features = false }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+sha3 = { workspace = true }
+syn = { workspace = true, features = ["extra-traits", "fold", "full", "visit"] }

--- a/precompiles/utils/macro/src/lib.rs
+++ b/precompiles/utils/macro/src/lib.rs
@@ -108,6 +108,7 @@ pub fn generate_function_selector(_: TokenStream, input: TokenStream) -> TokenSt
                 if let Lit::Str(lit_str) = lit {
                     let digest = Keccak256::digest(lit_str.value().as_bytes());
                     let selector = u32::from_be_bytes([digest[0], digest[1], digest[2], digest[3]]);
+
                     ident_expressions.push(variant.ident);
                     variant_expressions.push(Expr::Lit(ExprLit {
                         lit: Lit::Verbatim(Literal::u32_suffixed(selector)),

--- a/precompiles/utils/macro/tests/tests.rs
+++ b/precompiles/utils/macro/tests/tests.rs
@@ -32,15 +32,15 @@ pub enum Action {
 fn test_keccak256() {
     assert_eq!(
         &precompile_utils_macro::keccak256!(""),
-        Keccak256::digest(b"").as_ref(),
+        Keccak256::digest(b"").as_slice(),
     );
     assert_eq!(
         &precompile_utils_macro::keccak256!("toto()"),
-        Keccak256::digest(b"toto()").as_ref(),
+        Keccak256::digest(b"toto()").as_slice(),
     );
     assert_ne!(
         &precompile_utils_macro::keccak256!("toto()"),
-        Keccak256::digest(b"tata()").as_ref(),
+        Keccak256::digest(b"tata()").as_slice(),
     );
 }
 

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -1,46 +1,48 @@
 [package]
 name = "pallet-evm-precompile-xcm"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Basic XCM support for EVM."
-edition = "2021"
 version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-pallet-evm-precompile-assets-erc20 = { path = "../assets-erc20", default-features = false }
-pallet-xcm = { path = "../../frame/pallet-xcm", default-features = false }
-precompile-utils = { path = "../utils", default-features = false }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+pallet-evm-precompile-assets-erc20 = { workspace = true }
+pallet-xcm = { workspace = true }
+precompile-utils = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+pallet-assets = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 # Polkadot
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm = { workspace = true }
+xcm-executor = { workspace = true }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
-scale-info = "2.1.0"
-serde = "1.0.140"
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
-precompile-utils = { path = "../utils", features = ["testing"] }
+precompile-utils = { workspace = true, features = ["testing"] }
 
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37" }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-runtime = { workspace = true }
+xcm-builder = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -9,16 +9,16 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
+num_enum = { workspace = true }
 pallet-evm-precompile-assets-erc20 = { workspace = true }
 pallet-xcm = { workspace = true }
 precompile-utils = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-assets = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-std = { workspace = true }
@@ -47,7 +47,7 @@ xcm-builder = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -20,12 +20,12 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{AsEnsureOriginWithArg, Everything},
     weights::Weight,
 };
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 

--- a/precompiles/xvm/Cargo.toml
+++ b/precompiles/xvm/Cargo.toml
@@ -1,39 +1,41 @@
 [package]
 name = "pallet-evm-precompile-xvm"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Cross-VM call support for EVM."
-edition = "2021"
 version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
-log = "0.4.16"
-num_enum = { version = "0.5.3", default-features = false }
-pallet-xvm = { path = "../../frame/pallet-xvm", default-features = false }
-precompile-utils = { path = "../utils", default-features = false }
+log = { workspace = true }
+num_enum = { workspace = true, default-features = false }
+pallet-xvm = { workspace = true }
+precompile-utils = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["max-encoded-len"] }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
-scale-info = "2.1.0"
-serde = "1.0.100"
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
 
-precompile-utils = { path = "../utils", features = ["testing"] }
+precompile-utils = { workspace = true, features = ["testing"] }
 
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+pallet-balances = { workspace = true }
+pallet-timestamp = { workspace = true }
+sp-runtime = { workspace = true }
 
 [features]
 default = ["std"]

--- a/precompiles/xvm/Cargo.toml
+++ b/precompiles/xvm/Cargo.toml
@@ -9,14 +9,14 @@ repository.workspace = true
 
 [dependencies]
 log = { workspace = true }
-num_enum = { workspace = true, default-features = false }
+num_enum = { workspace = true }
 pallet-xvm = { workspace = true }
 precompile-utils = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", features = ["max-encoded-len"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-std = { workspace = true }
@@ -40,7 +40,7 @@ sp-runtime = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -19,11 +19,11 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(test, feature(assert_matches))]
 
-use codec::Decode;
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{AddressMapping, Precompile};
 use pallet_xvm::XvmContext;
+use parity_scale_codec::Decode;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 

--- a/precompiles/xvm/src/mock.rs
+++ b/precompiles/xvm/src/mock.rs
@@ -20,8 +20,8 @@
 
 use super::*;
 
-use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 

--- a/precompiles/xvm/src/tests.rs
+++ b/precompiles/xvm/src/tests.rs
@@ -19,7 +19,7 @@
 use crate::mock::*;
 use crate::*;
 
-use codec::Encode;
+use parity_scale_codec::Encode;
 use precompile_utils::testing::*;
 use precompile_utils::EvmDataWriter;
 

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 [dependencies]
 
 # third-party dependencies
-log = { workspace = true, default-features = false }
+log = { workspace = true }
 
 # Substrate dependencies
 frame-support = { workspace = true }

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -1,27 +1,29 @@
 [package]
 name = "xcm-primitives"
 version = "0.4.1"
-authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Common XCM primitives used by runtimes"
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 [dependencies]
 
 # third-party dependencies
-log = { version = "0.4", default-features = false }
+log = { workspace = true, default-features = false }
 
 # Substrate dependencies
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+frame-support = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # XCM dependencies
-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
-xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.37", default-features = false }
+xcm = { workspace = true }
+xcm-builder = { workspace = true }
+xcm-executor = { workspace = true }
 
 # Astar pallets
-pallet-xc-asset-config = { path = "../../frame/xc-asset-config", default-features = false }
+pallet-xc-asset-config = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/evm-tracing/Cargo.toml
+++ b/vendor/evm-tracing/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { workspace = true }
-hex = { workspace = true, features = ["serde"] }
-serde = { workspace = true, features = ["derive"] }
+ethereum-types = { workspace = true, features = ["std"] }
+hex = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Moonbeam
-evm-tracing-events = { workspace = true }
+evm-tracing-events = { workspace = true, features = ["std"] }
 moonbeam-rpc-primitives-debug = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
-sp-std = { workspace = true }
+parity-scale-codec = { workspace = true }
+sp-std = { workspace = true, features = ["std"] }

--- a/vendor/evm-tracing/Cargo.toml
+++ b/vendor/evm-tracing/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14" }
-hex = { version = "0.4", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+ethereum-types = { workspace = true }
+hex = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 # Moonbeam
-evm-tracing-events = { path = "../primitives/evm-tracing-events" }
-moonbeam-rpc-primitives-debug = { path = "../primitives/debug" }
+evm-tracing-events = { workspace = true }
+moonbeam-rpc-primitives-debug = { workspace = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+codec = { workspace = true, package = "parity-scale-codec" }
+sp-std = { workspace = true }

--- a/vendor/evm-tracing/src/formatters/blockscout.rs
+++ b/vendor/evm-tracing/src/formatters/blockscout.rs
@@ -20,8 +20,8 @@ use crate::types::{
     single::{Call, TransactionTrace},
     CallResult, CallType, CreateResult,
 };
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use serde::Serialize;
 
 pub struct Formatter;

--- a/vendor/evm-tracing/src/formatters/call_tracer.rs
+++ b/vendor/evm-tracing/src/formatters/call_tracer.rs
@@ -25,8 +25,8 @@ use crate::listeners::call_list::Listener;
 use crate::types::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::{cmp::Ordering, vec::Vec};
 
 pub struct Formatter;

--- a/vendor/evm-tracing/src/types/block.rs
+++ b/vendor/evm-tracing/src/types/block.rs
@@ -19,8 +19,8 @@
 use super::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]

--- a/vendor/evm-tracing/src/types/mod.rs
+++ b/vendor/evm-tracing/src/types/mod.rs
@@ -18,8 +18,8 @@
 
 extern crate alloc;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 pub mod block;

--- a/vendor/evm-tracing/src/types/single.rs
+++ b/vendor/evm-tracing/src/types/single.rs
@@ -22,8 +22,8 @@
 use super::serialization::*;
 use serde::Serialize;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H256, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode, Serialize)]

--- a/vendor/primitives/debug/Cargo.toml
+++ b/vendor/primitives/debug/Cargo.toml
@@ -8,20 +8,20 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-environmental = { version = "1.1.2", default-features = false }
-ethereum = { version = "0.14.0", default-features = false, features = ["with-codec"] }
-ethereum-types = { version = "0.14", default-features = false }
-hex = { version = "0.4", optional = true, features = ["serde"] }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-serde_json = { version = "1.0", optional = true }
+environmental = { workspace = true, default-features = false }
+ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
+ethereum-types = { workspace = true, default-features = false }
+hex = { workspace = true, optional = true, features = ["serde"] }
+serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+sp-api = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/primitives/debug/Cargo.toml
+++ b/vendor/primitives/debug/Cargo.toml
@@ -8,15 +8,15 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-environmental = { workspace = true, default-features = false }
-ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
-ethereum-types = { workspace = true, default-features = false }
-hex = { workspace = true, optional = true, features = ["serde"] }
-serde = { workspace = true, optional = true, features = ["derive"] }
+environmental = { workspace = true }
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+hex = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 sp-api = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
@@ -26,7 +26,7 @@ sp-std = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"environmental/std",
 	"ethereum-types/std",
 	"ethereum/std",

--- a/vendor/primitives/debug/src/lib.rs
+++ b/vendor/primitives/debug/src/lib.rs
@@ -16,9 +16,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::{Decode, Encode};
 use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
 use ethereum_types::H256;
+use parity_scale_codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {

--- a/vendor/primitives/evm-tracing-events/Cargo.toml
+++ b/vendor/primitives/evm-tracing-events/Cargo.toml
@@ -8,23 +8,23 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-environmental = { workspace = true, default-features = false }
+environmental = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 sp-runtime-interface = { workspace = true }
 
 # Ethereum
-ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
-ethereum-types = { workspace = true, default-features = false }
-evm = { workspace = true, default-features = false, features = ["with-codec"] }
-evm-gasometer = { workspace = true, default-features = false }
-evm-runtime = { workspace = true, default-features = false }
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+evm = { workspace = true, features = ["with-codec"] }
+evm-gasometer = { workspace = true }
+evm-runtime = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"environmental/std",
 	"ethereum-types/std",
 	"ethereum/std",

--- a/vendor/primitives/evm-tracing-events/Cargo.toml
+++ b/vendor/primitives/evm-tracing-events/Cargo.toml
@@ -8,18 +8,18 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-environmental = { version = "1.1.2", default-features = false }
+environmental = { workspace = true, default-features = false }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+sp-runtime-interface = { workspace = true }
 
 # Ethereum
-ethereum = { version = "0.14.0", default-features = false, features = ["with-codec"] }
-ethereum-types = { version = "0.14", default-features = false }
-evm = { version = "0.37.0", default-features = false, features = ["with-codec"] }
-evm-gasometer = { version = "0.37.0", default-features = false }
-evm-runtime = { version = "0.37.0", default-features = false }
+ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
+ethereum-types = { workspace = true, default-features = false }
+evm = { workspace = true, default-features = false, features = ["with-codec"] }
+evm-gasometer = { workspace = true, default-features = false }
+evm-runtime = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]

--- a/vendor/primitives/evm-tracing-events/src/evm.rs
+++ b/vendor/primitives/evm-tracing-events/src/evm.rs
@@ -17,9 +17,9 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
 use evm::ExitReason;
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct Transfer {

--- a/vendor/primitives/evm-tracing-events/src/gasometer.rs
+++ b/vendor/primitives/evm-tracing-events/src/gasometer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Debug, Default, Copy, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct Snapshot {

--- a/vendor/primitives/evm-tracing-events/src/lib.rs
+++ b/vendor/primitives/evm-tracing-events/src/lib.rs
@@ -39,8 +39,8 @@ pub use self::evm::EvmEvent;
 pub use gasometer::GasometerEvent;
 pub use runtime::RuntimeEvent;
 
-use codec::{Decode, Encode};
 use ethereum_types::{H160, U256};
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime_interface::pass_by::PassByCodec;
 
 environmental::environmental!(listener: dyn Listener + 'static);

--- a/vendor/primitives/evm-tracing-events/src/runtime.rs
+++ b/vendor/primitives/evm-tracing-events/src/runtime.rs
@@ -18,9 +18,9 @@ extern crate alloc;
 
 use super::Context;
 use alloc::vec::Vec;
-use codec::{Decode, Encode};
 use ethereum_types::{H160, H256, U256};
 pub use evm::{ExitError, ExitReason, ExitSucceed, Opcode};
+use parity_scale_codec::{Decode, Encode};
 
 #[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
 pub struct Stack {

--- a/vendor/primitives/txpool/Cargo.toml
+++ b/vendor/primitives/txpool/Cargo.toml
@@ -8,14 +8,14 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", default-features = false, features = ["with-codec"] }
+ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+sp-api = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/primitives/txpool/Cargo.toml
+++ b/vendor/primitives/txpool/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
+ethereum = { workspace = true, features = ["with-codec"] }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 sp-api = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }

--- a/vendor/primitives/txpool/src/lib.rs
+++ b/vendor/primitives/txpool/src/lib.rs
@@ -19,8 +19,8 @@
 #![allow(clippy::unnecessary_mut_passed)]
 #![allow(clippy::too_many_arguments)]
 
-use codec::{Decode, Encode};
 pub use ethereum::{TransactionV0 as LegacyTransaction, TransactionV2 as Transaction};
+use parity_scale_codec::{Decode, Encode};
 use sp_runtime::traits::Block as BlockT;
 use sp_std::vec::Vec;
 

--- a/vendor/rpc-core/debug/Cargo.toml
+++ b/vendor/rpc-core/debug/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { workspace = true }
+ethereum-types = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["compat"] }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
 moonbeam-client-evm-tracing = { workspace = true }
 moonbeam-rpc-core-types = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
-sp-core = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }

--- a/vendor/rpc-core/debug/Cargo.toml
+++ b/vendor/rpc-core/debug/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.14"
-futures = { version = "0.3", features = ["compat"] }
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
-moonbeam-rpc-core-types = { path = "../types" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+ethereum-types = { workspace = true }
+futures = { workspace = true, features = ["compat"] }
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+moonbeam-client-evm-tracing = { workspace = true }
+moonbeam-rpc-core-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sp-core = { workspace = true }

--- a/vendor/rpc-core/trace/Cargo.toml
+++ b/vendor/rpc-core/trace/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum-types = { workspace = true }
+ethereum-types = { workspace = true, features = ["std"] }
 futures = { workspace = true, features = ["compat"] }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
 moonbeam-client-evm-tracing = { workspace = true }
 moonbeam-rpc-core-types = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vendor/rpc-core/trace/Cargo.toml
+++ b/vendor/rpc-core/trace/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum-types = "0.14"
-futures = { version = "0.3.1", features = ["compat"] }
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
-moonbeam-rpc-core-types = { path = "../types" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+ethereum-types = { workspace = true }
+futures = { workspace = true, features = ["compat"] }
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+moonbeam-client-evm-tracing = { workspace = true }
+moonbeam-rpc-core-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/vendor/rpc-core/txpool/Cargo.toml
+++ b/vendor/rpc-core/txpool/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
-ethereum-types = { workspace = true }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
-serde = { workspace = true, features = ["derive"] }
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true, features = ["std"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 fc-rpc-core = { workspace = true }

--- a/vendor/rpc-core/txpool/Cargo.toml
+++ b/vendor/rpc-core/txpool/Cargo.toml
@@ -8,10 +8,10 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", default-features = false, features = ["with-codec"] }
-ethereum-types = "0.14"
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
-fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+fc-rpc-core = { workspace = true }

--- a/vendor/rpc-core/types/Cargo.toml
+++ b/vendor/rpc-core/types/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.14"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+ethereum-types = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }

--- a/vendor/rpc-core/types/Cargo.toml
+++ b/vendor/rpc-core/types/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
+ethereum-types = { workspace = true, features = ["std"] }
+serde = { workspace = true }
 serde_json = { workspace = true }

--- a/vendor/rpc/debug/Cargo.toml
+++ b/vendor/rpc/debug/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 futures = { workspace = true, features = ["compat"] }
 hex-literal = { workspace = true }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 
 # Moonbeam
@@ -22,16 +22,16 @@ moonbeam-rpc-primitives-debug = { workspace = true }
 # Substrate
 sc-client-api = { workspace = true }
 sc-utils = { workspace = true }
-sp-api = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
 sp-block-builder = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-core = { workspace = true }
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
+sp-core = { workspace = true, features = ["std"] }
+sp-io = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
 
 # Frontier
-ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
-ethereum-types = { workspace = true }
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true, features = ["std"] }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true }
 fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }

--- a/vendor/rpc/debug/Cargo.toml
+++ b/vendor/rpc/debug/Cargo.toml
@@ -8,31 +8,31 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-futures = { version = "0.3", features = ["compat"] }
-hex-literal = "0.3.4"
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-tokio = { version = "1.10", features = ["sync", "time"] }
+futures = { workspace = true, features = ["compat"] }
+hex-literal = { workspace = true }
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+tokio = { workspace = true, features = ["sync", "time"] }
 
 # Moonbeam
-moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
-moonbeam-rpc-core-debug = { path = "../../rpc-core/debug" }
-moonbeam-rpc-core-types = { path = "../../rpc-core/types" }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/debug" }
+moonbeam-client-evm-tracing = { workspace = true }
+moonbeam-rpc-core-debug = { workspace = true }
+moonbeam-rpc-core-types = { workspace = true }
+moonbeam-rpc-primitives-debug = { workspace = true }
 
 # Substrate
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sc-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-client-api = { workspace = true }
+sc-utils = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
 
 # Frontier
-ethereum = { version = "0.14.0", default-features = false, features = ["with-codec"] }
-ethereum-types = "0.14"
-fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
-fc-db = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
-fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", features = ["rpc-binary-search-estimate"] }
-fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+ethereum = { workspace = true, default-features = false, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+fc-consensus = { workspace = true }
+fc-db = { workspace = true }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }
+fp-rpc = { workspace = true }

--- a/vendor/rpc/trace/Cargo.toml
+++ b/vendor/rpc/trace/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { workspace = true, features = ["with-codec"] }
-ethereum-types = { workspace = true }
+ethereum = { workspace = true, features = ["with-codec", "std"] }
+ethereum-types = { workspace = true, features = ["std"] }
 futures = { workspace = true }
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
-serde = { workspace = true, features = ["derive"] }
-sha3 = { workspace = true }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
+serde = { workspace = true }
+sha3 = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["sync", "time"] }
 tracing = { workspace = true }
 
@@ -27,12 +27,12 @@ moonbeam-rpc-primitives-debug = { workspace = true }
 sc-client-api = { workspace = true }
 sc-network = { workspace = true }
 sc-utils = { workspace = true }
-sp-api = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
 sp-block-builder = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
-sp-std = { workspace = true }
+sp-io = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
+sp-std = { workspace = true, features = ["std"] }
 sp-transaction-pool = { workspace = true }
 
 # Frontier

--- a/vendor/rpc/trace/Cargo.toml
+++ b/vendor/rpc/trace/Cargo.toml
@@ -8,35 +8,35 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", features = ["with-codec"] }
-ethereum-types = "0.14"
-futures = { version = "0.3" }
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10"
-tokio = { version = "1.10", features = ["sync", "time"] }
-tracing = "0.1.34"
+ethereum = { workspace = true, features = ["with-codec"] }
+ethereum-types = { workspace = true }
+futures = { workspace = true }
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+serde = { workspace = true, features = ["derive"] }
+sha3 = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time"] }
+tracing = { workspace = true }
 
 # Moonbeam
-moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
-moonbeam-rpc-core-trace = { path = "../../rpc-core/trace" }
-moonbeam-rpc-core-types = { path = "../../rpc-core/types" }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/debug" }
+moonbeam-client-evm-tracing = { workspace = true }
+moonbeam-rpc-core-trace = { workspace = true }
+moonbeam-rpc-core-types = { workspace = true }
+moonbeam-rpc-primitives-debug = { workspace = true }
 
 # Substrate
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sc-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+sc-client-api = { workspace = true }
+sc-network = { workspace = true }
+sc-utils = { workspace = true }
+sp-api = { workspace = true }
+sp-block-builder = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+sp-transaction-pool = { workspace = true }
 
 # Frontier
-fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
-fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", features = ["rpc-binary-search-estimate"] }
-fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
-fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37" }
+fc-consensus = { workspace = true }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }
+fc-rpc-core = { workspace = true }
+fp-rpc = { workspace = true }

--- a/vendor/rpc/txpool/Cargo.toml
+++ b/vendor/rpc/txpool/Cargo.toml
@@ -8,25 +8,25 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+jsonrpsee = { workspace = true, features = ["macros", "server"] }
 rlp = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
-sha3 = { workspace = true }
+serde = { workspace = true }
+sha3 = { workspace = true, features = ["std"] }
 
 # Moonbeam
 moonbeam-rpc-core-txpool = { workspace = true }
 moonbeam-rpc-primitives-txpool = { workspace = true }
 
 # Substrate
-frame-system = { workspace = true }
+frame-system = { workspace = true, features = ["std"] }
 sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
-sp-api = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
 sp-blockchain = { workspace = true }
-sp-io = { workspace = true }
-sp-runtime = { workspace = true }
-sp-std = { workspace = true }
+sp-io = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
+sp-std = { workspace = true, features = ["std"] }
 
 # Frontier
-ethereum-types = { workspace = true }
+ethereum-types = { workspace = true, features = ["std"] }
 fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }

--- a/vendor/rpc/txpool/Cargo.toml
+++ b/vendor/rpc/txpool/Cargo.toml
@@ -8,25 +8,25 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", default-features = false, features = ["macros", "server"] }
-rlp = "0.5"
-serde = { version = "1.0", features = ["derive"] }
-sha3 = "0.10"
+jsonrpsee = { workspace = true, default-features = false, features = ["macros", "server"] }
+rlp = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+sha3 = { workspace = true }
 
 # Moonbeam
-moonbeam-rpc-core-txpool = { path = "../../rpc-core/txpool" }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/txpool" }
+moonbeam-rpc-core-txpool = { workspace = true }
+moonbeam-rpc-primitives-txpool = { workspace = true }
 
 # Substrate
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
+frame-system = { workspace = true }
+sc-transaction-pool = { workspace = true }
+sc-transaction-pool-api = { workspace = true }
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-ethereum-types = "0.14"
-fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", features = ["rpc-binary-search-estimate"] }
+ethereum-types = { workspace = true }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }

--- a/vendor/runtime/evm_tracer/Cargo.toml
+++ b/vendor/runtime/evm_tracer/Cargo.toml
@@ -10,28 +10,28 @@ version = "0.1.0"
 [dependencies]
 
 # Moonbeam
-evm-tracing-events = { workspace = true, default-features = false, features = ["evm-tracing"] }
-moonbeam-primitives-ext = { workspace = true, default-features = false }
+evm-tracing-events = { workspace = true, features = ["evm-tracing"] }
+moonbeam-primitives-ext = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
+parity-scale-codec = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 # Frontier
-ethereum-types = { workspace = true, default-features = false }
-evm = { workspace = true, default-features = false, features = ["with-codec"] }
-evm-gasometer = { workspace = true, default-features = false }
-evm-runtime = { workspace = true, default-features = false }
+ethereum-types = { workspace = true }
+evm = { workspace = true, features = ["with-codec"] }
+evm-gasometer = { workspace = true }
+evm-runtime = { workspace = true }
 fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
 
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"ethereum-types/std",
 	"evm-gasometer/std",
 	"evm-runtime/std",

--- a/vendor/runtime/evm_tracer/Cargo.toml
+++ b/vendor/runtime/evm_tracer/Cargo.toml
@@ -10,23 +10,23 @@ version = "0.1.0"
 [dependencies]
 
 # Moonbeam
-evm-tracing-events = { path = "../../primitives/evm-tracing-events", default-features = false, features = ["evm-tracing"] }
-moonbeam-primitives-ext = { path = "../ext", default-features = false }
+evm-tracing-events = { workspace = true, default-features = false, features = ["evm-tracing"] }
+moonbeam-primitives-ext = { workspace = true, default-features = false }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec" }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
-ethereum-types = { version = "0.14", default-features = false }
-evm = { version = "0.37.0", default-features = false, features = ["with-codec"] }
-evm-gasometer = { version = "0.37.0", default-features = false }
-evm-runtime = { version = "0.37.0", default-features = false }
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.37", default-features = false, features = ["forbid-evm-reentrancy"] }
+ethereum-types = { workspace = true, default-features = false }
+evm = { workspace = true, default-features = false, features = ["with-codec"] }
+evm-gasometer = { workspace = true, default-features = false }
+evm-runtime = { workspace = true, default-features = false }
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/runtime/evm_tracer/src/lib.rs
+++ b/vendor/runtime/evm_tracer/src/lib.rs
@@ -25,8 +25,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod tracer {
-    use codec::Encode;
     use evm_tracing_events::{EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};
+    use parity_scale_codec::Encode;
 
     use evm::tracing::{using as evm_using, EventListener as EvmListener};
     use evm_gasometer::tracing::{using as gasometer_using, EventListener as GasometerListener};

--- a/vendor/runtime/ext/Cargo.toml
+++ b/vendor/runtime/ext/Cargo.toml
@@ -8,13 +8,13 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { workspace = true, default-features = false }
+ethereum-types = { workspace = true }
 
 # Moonbeam
-evm-tracing-events = { workspace = true, default-features = false }
+evm-tracing-events = { workspace = true }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec", version = "3.0.0", default-features = false }
+parity-scale-codec = { workspace = true }
 sp-externalities = { workspace = true }
 sp-runtime-interface = { workspace = true }
 sp-std = { workspace = true }
@@ -22,7 +22,7 @@ sp-std = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"codec/std",
+	"parity-scale-codec/std",
 	"ethereum-types/std",
 	"evm-tracing-events/std",
 	"sp-externalities/std",

--- a/vendor/runtime/ext/Cargo.toml
+++ b/vendor/runtime/ext/Cargo.toml
@@ -8,16 +8,16 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14", default-features = false }
+ethereum-types = { workspace = true, default-features = false }
 
 # Moonbeam
-evm-tracing-events = { path = "../../primitives/evm-tracing-events", default-features = false }
+evm-tracing-events = { workspace = true, default-features = false }
 
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-externalities = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-runtime-interface = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", default-features = false }
+codec = { workspace = true, package = "parity-scale-codec", version = "3.0.0", default-features = false }
+sp-externalities = { workspace = true }
+sp-runtime-interface = { workspace = true }
+sp-std = { workspace = true }
 
 [features]
 default = ["std"]

--- a/vendor/runtime/ext/src/lib.rs
+++ b/vendor/runtime/ext/src/lib.rs
@@ -25,7 +25,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use sp_runtime_interface::runtime_interface;
 
-use codec::Decode;
+use parity_scale_codec::Decode;
 use sp_std::vec::Vec;
 
 use evm_tracing_events::{Event, EvmEvent, GasometerEvent, RuntimeEvent, StepEventFilter};


### PR DESCRIPTION
**Pull Request Summary**

Utilize workspace inheritance for `astar-frame` repository.

Makes tracking of used versions simpler by keeping it in a single file.
Also reduces the possibility of unnecessarily using different deps version in different crates, even though it's not necessary.
