### PR TITLE
`xvm_call` now returns output- or encoded error data

### DIFF
--- a/chain-extensions/xvm/src/lib.rs
+++ b/chain-extensions/xvm/src/lib.rs
@@ -82,29 +82,32 @@ where
                     env: None,
                 };
 
-                let call_result = pallet_xvm::Pallet::<T>::xvm_call(
-                    RawOrigin::Signed(caller).into(),
-                    xvm_context,
-                    to,
-                    input,
-                );
+                let from = R::AddressMapping::into_account_id(caller);
+                let call_result = pallet_xvm::Pallet::<R>::xvm_bare_call(context, from, to, input);
 
-                // Adjust the actual weight used by the call if needed.
-                let actual_weight = match call_result {
-                    Ok(e) => e.actual_weight,
-                    Err(e) => e.post_info.actual_weight,
-                };
-                if let Some(actual_weight) = actual_weight {
-                    env.adjust_weight(charged_weight, actual_weight);
-                }
+                let actual_weight = pallet_xvm::consumed_weight(&call_result);
+                env.adjust_weight(charged_weight, actual_weight);
 
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = XvmExecutionResult::try_from(e.error)?;
-                        Ok(RetVal::Converging(mapped_error as u32))
+                match &call_result {
+                    Ok(success) => {
+                        log::trace!(
+                            target: "xvm-extension::xvm_call",
+                            "success: {:?}", success
+                        );
+
+                        env.write(success.output(), false, None);
+                        Ok(RetVal::Converging(XvmExecutionResult::Success as u32))
                     }
-                    Ok(_) => Ok(RetVal::Converging(XvmExecutionResult::Success as u32)),
-                };
+
+                    Err(failure) => {
+                        log::trace!(
+                            target: "xvm-extension::xvm_call",
+                            "failure: {:?}", failure
+                        );
+
+                        Ok(RetVal::Converging(failure.error() as u32))
+                    }
+                }
             }
         }
     }

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -88,7 +88,7 @@ where
         );
 
         Ok(XvmCallOk {
-            output: Default::default(), // TODO: Fill output vec with response from the call
+            output: info.value, //Default::default(), // TODO: Fill output vec with response from the call
             consumed_weight: T::GasWeightMapping::gas_to_weight(
                 info.used_gas.unique_saturated_into(),
                 false,

--- a/frame/pallet-xvm/src/evm.rs
+++ b/frame/pallet-xvm/src/evm.rs
@@ -88,7 +88,7 @@ where
         );
 
         Ok(XvmCallOk {
-            output: info.value, //Default::default(), // TODO: Fill output vec with response from the call
+            output: info.value,
             consumed_weight: T::GasWeightMapping::gas_to_weight(
                 info.used_gas.unique_saturated_into(),
                 false,

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -80,6 +80,12 @@ pub struct XvmCallOk {
     consumed_weight: u64,
 }
 
+impl XvmCallOk {
+    pub fn output(&self) -> &Vec<u8> {
+        &self.output
+    }
+}
+
 /// Denotes an successful XVM call execution
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, scale_info::TypeInfo)]
 pub struct XvmCallError {
@@ -88,6 +94,12 @@ pub struct XvmCallError {
     error: XvmError,
     /// Total consumed weight. This is in context of Substrate (1 unit of weight ~ 1 ps of execution time)
     consumed_weight: u64,
+}
+
+impl XvmCallError {
+    pub fn error(&self) -> &XvmError {
+        &self.error
+    }
 }
 
 /// Result for executing X-VM calls

--- a/frame/pallet-xvm/src/lib.rs
+++ b/frame/pallet-xvm/src/lib.rs
@@ -81,7 +81,7 @@ pub struct XvmCallOk {
 }
 
 impl XvmCallOk {
-    pub fn output(&self) -> &Vec<u8> {
+    pub fn output(&self) -> &[u8] {
         &self.output
     }
 }

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -64,13 +64,11 @@ pub mod pallet {
 
     impl<T: Config> Pallet<T> {
         pub fn xvm_bare_call(
-            // origin: OriginFor<T>,
             context: XvmContext,
             from: T::AccountId,
             to: Vec<u8>,
             input: Vec<u8>,
         ) -> XvmResult {
-            // let from = ensure_signed(origin)?;
             let result = T::SyncVM::xvm_call(context, from, to, input);
 
             log::trace!(

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -63,6 +63,12 @@ pub mod pallet {
     }
 
     impl<T: Config> Pallet<T> {
+        /// Internal interface for cross-pallet invocation.
+        /// Essentially does the same thing as `xvm_call`, but a bit differently:
+        ///   - It does not verify origin
+        ///   - It does not use `Dispatchable` API (cannot be called from tx)
+        ///   - It does not deposit event upon completion
+        ///   - It returns `XvmResult` letting the caller get return data directly
         pub fn xvm_bare_call(
             context: XvmContext,
             from: T::AccountId,

--- a/frame/pallet-xvm/src/pallet/mod.rs
+++ b/frame/pallet-xvm/src/pallet/mod.rs
@@ -62,6 +62,26 @@ pub mod pallet {
         XvmQuery { result: Result<Vec<u8>, XvmError> },
     }
 
+    impl<T: Config> Pallet<T> {
+        pub fn xvm_bare_call(
+            // origin: OriginFor<T>,
+            context: XvmContext,
+            from: T::AccountId,
+            to: Vec<u8>,
+            input: Vec<u8>,
+        ) -> XvmResult {
+            // let from = ensure_signed(origin)?;
+            let result = T::SyncVM::xvm_call(context, from, to, input);
+
+            log::trace!(
+                target: "xvm::pallet::xvm_bare_call",
+                "Execution result: {:?}", result
+            );
+
+            result
+        }
+    }
+
     #[pallet::call]
     impl<T: Config> Pallet<T> {
         #[pallet::call_index(0)]

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -63,7 +63,7 @@ where
         })?;
         let call_result = pallet_contracts::Pallet::<T>::bare_call(
             from, // no need to check origin, we consider it signed here
-            dest, // no need to lookup since it's already `AccountId`
+            dest,
             Default::default(),
             gas_limit.into(),
             None,
@@ -83,7 +83,6 @@ where
             .ref_time();
 
         match call_result.result {
-            // FIXME What about `success.flags`?
             Ok(success) => Ok(XvmCallOk {
                 output: success.data,
                 consumed_weight,

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -24,8 +24,8 @@ use frame_support::traits::Currency;
 use pallet_contracts::weights::WeightInfo;
 use scale_info::TypeInfo;
 use sp_runtime::traits::Get;
+use sp_runtime::traits::StaticLookup;
 use sp_std::fmt::Debug;
-
 pub struct WASM<I, T>(sp_std::marker::PhantomData<(I, T)>);
 
 type BalanceOf<T> = <<T as pallet_contracts::Config>::Currency as Currency<
@@ -57,6 +57,10 @@ where
             consumed_weight: PLACEHOLDER_WEIGHT,
         })?;
 
+        let dest = T::Lookup::lookup(dest).map_err(|error| XvmCallError {
+            error: XvmError::ExecutionError(Into::<&str>::into(error).into()),
+            consumed_weight: PLACEHOLDER_WEIGHT,
+        })?;
         let call_result = pallet_contracts::Pallet::<T>::bare_call(
             from, // no need to check origin, we consider it signed here
             dest, // no need to lookup since it's already `AccountId`

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -20,7 +20,6 @@
 
 use crate::*;
 use frame_support::traits::Currency;
-use pallet_contracts::weights::WeightInfo;
 use parity_scale_codec::HasCompact;
 use scale_info::TypeInfo;
 use sp_runtime::traits::Get;
@@ -77,10 +76,7 @@ where
             "WASM XVM call result: {:?}", call_result
         );
 
-        let consumed_weight = call_result
-            .gas_consumed
-            .saturating_add(T::WeightInfo::call())
-            .ref_time();
+        let consumed_weight = call_result.gas_consumed.ref_time();
 
         match call_result.result {
             Ok(success) => Ok(XvmCallOk {

--- a/frame/pallet-xvm/src/wasm.rs
+++ b/frame/pallet-xvm/src/wasm.rs
@@ -21,6 +21,7 @@
 use crate::*;
 use codec::HasCompact;
 use frame_support::traits::Currency;
+use pallet_contracts::weights::WeightInfo;
 use scale_info::TypeInfo;
 use sp_runtime::traits::Get;
 use sp_std::fmt::Debug;
@@ -55,39 +56,39 @@ where
             error: XvmError::EncodingFailure,
             consumed_weight: PLACEHOLDER_WEIGHT,
         })?;
-        let res = pallet_contracts::Pallet::<T>::call(
-            frame_support::dispatch::RawOrigin::Signed(from).into(),
-            dest,
+
+        let call_result = pallet_contracts::Pallet::<T>::bare_call(
+            from, // no need to check origin, we consider it signed here
+            dest, // no need to lookup since it's already `AccountId`
             Default::default(),
             gas_limit.into(),
             None,
             input,
-        )
-        .map_err(|e| {
-            let consumed_weight = if let Some(weight) = e.post_info.actual_weight {
-                weight.ref_time()
-            } else {
-                gas_limit.ref_time()
-            };
-            XvmCallError {
-                error: XvmError::ExecutionError(Into::<&str>::into(e.error).into()),
-                consumed_weight,
-            }
-        })?;
+            false,
+            pallet_contracts::Determinism::Deterministic,
+        );
 
         log::trace!(
             target: "xvm::WASM::xvm_call",
-            "WASM XVM call result: {:?}", res
+            "WASM XVM call result: {:?}", call_result
         );
 
-        let consumed_weight = if let Some(weight) = res.actual_weight {
-            weight.ref_time()
-        } else {
-            gas_limit.ref_time()
-        };
-        Ok(XvmCallOk {
-            output: Default::default(), // TODO: Fill in with output from the call
-            consumed_weight,
-        })
+        let consumed_weight = call_result
+            .gas_consumed
+            .saturating_add(T::WeightInfo::call())
+            .ref_time();
+
+        match call_result.result {
+            // FIXME What about `success.flags`?
+            Ok(success) => Ok(XvmCallOk {
+                output: success.data,
+                consumed_weight,
+            }),
+
+            Err(error) => Err(XvmCallError {
+                error: XvmError::ExecutionError(Into::<&str>::into(error).into()),
+                consumed_weight,
+            }),
+        }
     }
 }

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -199,10 +199,11 @@ where
         // However while Substrate handle checking weight while not making the sender pay for it,
         // the EVM doesn't. It seems this safer to always record the costs to avoid unmetered
         // computations.
-        let used_weight = call
+        let result = call
             .dispatch(origin)
-            .map_err(|e| revert(alloc::format!("Dispatched call failed with error: {:?}", e)))?
-            .actual_weight;
+            .map_err(|e| revert(alloc::format!("Dispatched call failed with error: {:?}", e)))?;
+
+        let used_weight = result.actual_weight;
 
         let used_gas =
             Runtime::GasWeightMapping::weight_to_gas(used_weight.unwrap_or(dispatch_info.weight));

--- a/precompiles/xvm/Cargo.toml
+++ b/precompiles/xvm/Cargo.toml
@@ -51,4 +51,5 @@ std = [
 	"sp-core/std",
 	"sp-std/std",
 	"sp-io/std",
+	"sp-runtime/std",
 ]

--- a/precompiles/xvm/Cargo.toml
+++ b/precompiles/xvm/Cargo.toml
@@ -19,8 +19,8 @@ frame-system = { workspace = true }
 parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
-sp-std = { workspace = true }
 sp-runtime = { workspace = true }
+sp-std = { workspace = true }
 
 # Frontier
 fp-evm = { workspace = true }

--- a/precompiles/xvm/evm_sdk/XVM.sol
+++ b/precompiles/xvm/evm_sdk/XVM.sol
@@ -10,12 +10,11 @@ interface XVM {
      * @param to - call recepient
      * @param input - SCALE-encoded call arguments
      * @return success - operation outcome
-     * @return gas_spent - amount of gas (weight) that was consumed
      * @return data - output data if successful, error data on error
      */
     function xvm_call(
         bytes calldata context,
         bytes calldata to,
         bytes calldata input
-    ) external returns (bool success, uint64 gas_spent, bytes memory data);
+    ) external returns (bool success, bytes memory data);
 }

--- a/precompiles/xvm/evm_sdk/XVM.sol
+++ b/precompiles/xvm/evm_sdk/XVM.sol
@@ -5,14 +5,17 @@ pragma solidity ^0.8.0;
  */
 interface XVM {
     /**
-     * @dev Execute external VM call 
-     * @param context - execution context 
-     * @param to - call recepient 
-     * @param input - SCALE-encoded call arguments 
+     * @dev Execute external VM call
+     * @param context - execution context
+     * @param to - call recepient
+     * @param input - SCALE-encoded call arguments
+     * @return success - operation outcome
+     * @return gas - amount of gas (weight) that was consumed
+     * @return data - output data if successful, error data on error
      */
     function xvm_call(
         bytes calldata context,
         bytes calldata to,
-        bytes calldata input,
-    ) external;
+        bytes calldata input
+    ) external returns (bool success, uint64 gas, bytes memory data);
 }

--- a/precompiles/xvm/evm_sdk/XVM.sol
+++ b/precompiles/xvm/evm_sdk/XVM.sol
@@ -10,12 +10,12 @@ interface XVM {
      * @param to - call recepient
      * @param input - SCALE-encoded call arguments
      * @return success - operation outcome
-     * @return gas - amount of gas (weight) that was consumed
+     * @return gas_spent - amount of gas (weight) that was consumed
      * @return data - output data if successful, error data on error
      */
     function xvm_call(
         bytes calldata context,
         bytes calldata to,
         bytes calldata input
-    ) external returns (bool success, uint64 gas, bytes memory data);
+    ) external returns (bool success, uint64 gas_spent, bytes memory data);
 }

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -19,12 +19,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(test, feature(assert_matches))]
 
-use sp_runtime::codec::Encode;
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{AddressMapping, Precompile};
 use pallet_xvm::XvmContext;
 use parity_scale_codec::Decode;
+use sp_runtime::codec::Encode;
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -114,26 +114,9 @@ where
                         .write(false)
                         .write(pallet_xvm::consumed_weight(&result))
                         .write(error_buffer)
-                        .build()
+                        .build(),
                 ))
             }
         }
-
-        // Build call with origin.
-        // let origin = Some(R::AddressMapping::into_account_id(handle.context().caller)).into();
-        // let call = pallet_xvm::Call::<R>::xvm_call {
-        //     context,
-        //     to: call_to,
-        //     input: call_input,
-        // };
-
-        // Dispatch a call.
-        // The underlying logic will handle updating used EVM gas based on the weight of the executed call.
-        // let result = RuntimeHelper::<R>::try_dispatch(handle, origin, call)?;
-
-        // Ok(succeed(EvmDataWriter::new()
-        //     .write(true)
-        //     // .write() TODO write output
-        //     .build()))
     }
 }

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -97,7 +97,7 @@ where
 
         let from = R::AddressMapping::into_account_id(handle.context().caller);
         match &pallet_xvm::Pallet::<R>::xvm_bare_call(context, from, call_to, call_input) {
-            result @ Ok(success) => {
+            Ok(success) => {
                 log::trace!(
                     target: "xvm-precompile::xvm_call",
                     "success: {:?}", success
@@ -106,13 +106,12 @@ where
                 Ok(succeed(
                     EvmDataWriter::new()
                         .write(true)
-                        .write(pallet_xvm::consumed_weight(&result))
                         .write(Bytes(success.output().to_vec())) // TODO redundant clone
                         .build(),
                 ))
             }
 
-            result @ Err(failure) => {
+            Err(failure) => {
                 log::trace!(
                     target: "xvm-precompile::xvm_call",
                     "failure: {:?}", failure
@@ -124,7 +123,6 @@ where
                 Ok(succeed(
                     EvmDataWriter::new()
                         .write(false)
-                        .write(pallet_xvm::consumed_weight(&result))
                         .write(Bytes(error_buffer))
                         .build(),
                 ))

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -107,7 +107,7 @@ where
                     EvmDataWriter::new()
                         .write(true)
                         .write(pallet_xvm::consumed_weight(&result))
-                        .write(Bytes(success.output().clone())) // FIXME redundant clone
+                        .write(Bytes(success.output().to_vec())) // TODO redundant clone
                         .build(),
                 ))
             }

--- a/precompiles/xvm/src/lib.rs
+++ b/precompiles/xvm/src/lib.rs
@@ -30,7 +30,6 @@ use sp_std::prelude::*;
 
 use precompile_utils::{
     revert, succeed, Bytes, EvmDataWriter, EvmResult, FunctionModifier, PrecompileHandleExt,
-    RuntimeHelper,
 };
 
 #[cfg(test)]

--- a/precompiles/xvm/src/tests.rs
+++ b/precompiles/xvm/src/tests.rs
@@ -76,7 +76,6 @@ fn correct_arguments_works() {
             .execute_returns(
                 EvmDataWriter::new()
                     .write(false) // the XVM call should succeed but the internal should fail
-                    .write(1000000u64)
                     .write(vec![0u8])
                     .build(),
             );

--- a/precompiles/xvm/src/tests.rs
+++ b/precompiles/xvm/src/tests.rs
@@ -73,6 +73,12 @@ fn correct_arguments_works() {
                     .build(),
             )
             .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
+            .execute_returns(
+                EvmDataWriter::new()
+                    .write(false) // the XVM call should succeed but the internal should fail
+                    .write(1000000u64)
+                    .write(vec![0u8])
+                    .build(),
+            );
     })
 }


### PR DESCRIPTION
This PR adds the ability to get output data of a XVM call, or an error.

### Implementation details
- To get output data from pallet contracts, we now use `bare_call` which returns `ContractExecResult`
- In order to access output data from EVM _precompile_, a new `xvm_bare_call` API was added to the XVM _pallet_. 
- This allows doing direct cross pallet calls completely bypassing the `Dispatchable` API and without emitting events.
- `xvm_call` precompile now returns `(bool success, uint64 gas_spent, bytes memory data)`

### Notes
According to the design, XVM does not pose any restrictions on the format of the data returned from the call. It is considered to be an implementation detail of the XVM backend. For  example, error data returned from Wasm backend are in fact SCALE encoded `Result`. For EVM backend this can be different.

### How it was tested
- `flipper` contract from ink! examples was deployed on Shibuya/Zombienet
- Solidity contract was written that calls into flipper and gets its value
- Logs were checked to see that returned value does indeed contain value of flipper's bit