### PR TITLE
Fix for srtool issue with unstable build

### DIFF
--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -34,6 +34,8 @@ pallet-evm = { workspace = true }
 # Polkadot / XCM
 xcm = { workspace = true }
 
+assert_matches = { workspace = true }
+
 [dev-dependencies]
 hex-literal = { workspace = true }
 

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -21,7 +21,6 @@
 // along with Utils.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 extern crate alloc;
 

--- a/precompiles/utils/src/testing.rs
+++ b/precompiles/utils/src/testing.rs
@@ -20,7 +20,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Utils.  If not, see <http://www.gnu.org/licenses/>.
 use super::*;
-use core::assert_matches::assert_matches;
+use assert_matches::assert_matches;
 use fp_evm::{
     ExitReason, ExitSucceed, PrecompileOutput, PrecompileResult, PrecompileSet, Transfer,
 };


### PR DESCRIPTION
**Pull Request Summary**

Removes `assert_matches` as feature from precompile utils to fix srtool issue.
