### PR TITLE
disabled proof size in pre-charging

### DIFF
--- a/chain-extensions/xvm/src/lib.rs
+++ b/chain-extensions/xvm/src/lib.rs
@@ -68,7 +68,7 @@ where
             XvmFuncId::XvmCall => {
                 // We need to immediately charge for the worst case scenario. Gas equals Weight in pallet-contracts context.
                 let remaining_weight = env.ext().gas_meter().gas_left();
-                // We don't track used proof size, because we can't refund after.
+                // We don't track used proof size, so we can't refund after.
                 // So we will charge a 32KB dummy value as a temporary replacement. 
                 let charged_weight = env.charge_weight(remaining_weight.set_proof_size(32 * 1024))?;
 

--- a/chain-extensions/xvm/src/lib.rs
+++ b/chain-extensions/xvm/src/lib.rs
@@ -68,7 +68,7 @@ where
             XvmFuncId::XvmCall => {
                 // We need to immediately charge for the worst case scenario. Gas equals Weight in pallet-contracts context.
                 let remaining_weight = env.ext().gas_meter().gas_left();
-                let charged_weight = env.charge_weight(remaining_weight)?;
+                let charged_weight = env.charge_weight(remaining_weight.set_proof_size(0))?;
 
                 let caller = env.ext().caller().clone();
 

--- a/chain-extensions/xvm/src/lib.rs
+++ b/chain-extensions/xvm/src/lib.rs
@@ -69,8 +69,9 @@ where
                 // We need to immediately charge for the worst case scenario. Gas equals Weight in pallet-contracts context.
                 let remaining_weight = env.ext().gas_meter().gas_left();
                 // We don't track used proof size, so we can't refund after.
-                // So we will charge a 32KB dummy value as a temporary replacement. 
-                let charged_weight = env.charge_weight(remaining_weight.set_proof_size(32 * 1024))?;
+                // So we will charge a 32KB dummy value as a temporary replacement.
+                let charged_weight =
+                    env.charge_weight(remaining_weight.set_proof_size(32 * 1024))?;
 
                 let caller = env.ext().caller().clone();
 


### PR DESCRIPTION
**Pull Request Summary**
Disabled proof size usage in pre-charging because it's impossible to make a reset later on.

This causes the wrong estimation in polkadot js and also may cause "exhaust block limit"

**Check list**
- [ ] added unit tests
- [ ] updated documentation
