### PR TITLE
update precompile-xcm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,9 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.3
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39", default-features = false }
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39", default-features = false }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39", default-features = false }
+orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.39", default-features = false }
+orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.39", default-features = false }
+orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", branch = "polkadot-v0.9.39", default-features = false }
 
 # (native)
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.39" }

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -107,8 +107,7 @@ impl<K: Kind, S: Get<u32>> EvmData for BoundedBytesString<K, S> {
         let range = inner_reader.move_cursor(array_size)?;
 
         let data = inner_reader
-            .input
-            .get(range)
+            .get_input_from_range(range)
             .ok_or_else(|| revert(K::signature()))?;
 
         let bytes = Self {

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -23,6 +23,7 @@
 use super::*;
 use alloc::borrow::ToOwned;
 use sp_core::{ConstU32, Get};
+pub use alloc::string::String;
 
 type ConstU32Max = ConstU32<{ u32::MAX }>;
 

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -146,7 +146,6 @@ impl<K: Kind, S: Get<u32>> EvmData for BoundedBytesString<K, S> {
     fn has_static_size() -> bool {
         false
     }
-
 }
 
 // BytesString <=> Vec/&[u8]

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -107,7 +107,7 @@ impl<K: Kind, S: Get<u32>> EvmData for BoundedBytesString<K, S> {
         let range = inner_reader.move_cursor(array_size)?;
 
         let data = inner_reader
-            .input()
+            .input
             .get(range)
             .ok_or_else(|| revert(K::signature()))?;
 
@@ -147,9 +147,6 @@ impl<K: Kind, S: Get<u32>> EvmData for BoundedBytesString<K, S> {
         false
     }
 
-    // fn signature() -> String {
-    // 	K::signature()
-    // }
 }
 
 // BytesString <=> Vec/&[u8]

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -1,18 +1,24 @@
-// Copyright 2019-2022 PureStake Inc.
-// This file is part of Moonbeam.
+// This file is part of Astar.
 
-// Moonbeam is free software: you can redistribute it and/or modify
+// Copyright 2019-2022 PureStake Inc.
+// Copyright (C) 2022-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Utils package, originally developed by Purestake Inc.
+// Utils package used in Astar Network in terms of GPLv3.
+//
+// Utils is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Moonbeam is distributed in the hope that it will be useful,
+// Utils is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+// along with Utils.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
 use alloc::borrow::ToOwned;

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -1,0 +1,218 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use alloc::borrow::ToOwned;
+use sp_core::{ConstU32, Get};
+
+type ConstU32Max = ConstU32<{ u32::MAX }>;
+
+pub type UnboundedBytes = BoundedBytesString<BytesKind, ConstU32Max>;
+pub type BoundedBytes<S> = BoundedBytesString<BytesKind, S>;
+
+trait Kind {
+    fn signature() -> String;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BytesKind;
+
+impl Kind for BytesKind {
+    fn signature() -> String {
+        String::from("bytes")
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StringKind;
+
+impl Kind for StringKind {
+    fn signature() -> String {
+        String::from("string")
+    }
+}
+
+/// The `bytes/string` type of Solidity.
+/// It is different from `Vec<u8>` which will be serialized with padding for each `u8` element
+/// of the array, while `Bytes` is tightly packed.
+#[derive(Debug)]
+pub struct BoundedBytesString<K, S> {
+    data: Vec<u8>,
+    _phantom: PhantomData<(K, S)>,
+}
+
+impl<K: Kind, S: Get<u32>> Clone for BoundedBytesString<K, S> {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<K1, S1, K2, S2> PartialEq<BoundedBytesString<K2, S2>> for BoundedBytesString<K1, S1> {
+    fn eq(&self, other: &BoundedBytesString<K2, S2>) -> bool {
+        self.data.eq(&other.data)
+    }
+}
+
+impl<K, S> Eq for BoundedBytesString<K, S> {}
+
+impl<K, S: Get<u32>> BoundedBytesString<K, S> {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn as_str(&self) -> Result<&str, sp_std::str::Utf8Error> {
+        sp_std::str::from_utf8(&self.data)
+    }
+}
+
+impl<K: Kind, S: Get<u32>> EvmData for BoundedBytesString<K, S> {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let mut inner_reader = reader.read_pointer()?;
+
+        // Read bytes/string size.
+        let array_size: usize = inner_reader
+            .read::<U256>()
+            .map_err(|_| revert("length, out of bounds"))?
+            .try_into()
+            .map_err(|_| revert("length, value too large"))?;
+
+        if array_size > S::get() as usize {
+            return Err(revert("length, value too large").into());
+        }
+
+        // Get valid range over the bytes data.
+        let range = inner_reader.move_cursor(array_size)?;
+
+        let data = inner_reader
+            .input()
+            .get(range)
+            .ok_or_else(|| revert(K::signature()))?;
+
+        let bytes = Self {
+            data: data.to_owned(),
+            _phantom: PhantomData,
+        };
+
+        Ok(bytes)
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        let value: Vec<_> = value.into();
+        let length = value.len();
+
+        // Pad the data.
+        // Leave it as is if a multiple of 32, otherwise pad to next
+        // multiple or 32.
+        let chunks = length / 32;
+        let padded_size = match length % 32 {
+            0 => chunks * 32,
+            _ => (chunks + 1) * 32,
+        };
+
+        let mut value = value.to_vec();
+        value.resize(padded_size, 0);
+
+        writer.write_pointer(
+            EvmDataWriter::new()
+                .write(U256::from(length))
+                .write_raw_bytes(&value)
+                .build(),
+        );
+    }
+
+    fn has_static_size() -> bool {
+        false
+    }
+
+    // fn signature() -> String {
+    // 	K::signature()
+    // }
+}
+
+// BytesString <=> Vec/&[u8]
+
+impl<K, S> From<BoundedBytesString<K, S>> for Vec<u8> {
+    fn from(value: BoundedBytesString<K, S>) -> Self {
+        value.data
+    }
+}
+
+impl<K, S> From<Vec<u8>> for BoundedBytesString<K, S> {
+    fn from(value: Vec<u8>) -> Self {
+        Self {
+            data: value,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<K, S> From<&[u8]> for BoundedBytesString<K, S> {
+    fn from(value: &[u8]) -> Self {
+        Self {
+            data: value.to_vec(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<K, S, const N: usize> From<[u8; N]> for BoundedBytesString<K, S> {
+    fn from(value: [u8; N]) -> Self {
+        Self {
+            data: value.to_vec(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<K, S, const N: usize> From<&[u8; N]> for BoundedBytesString<K, S> {
+    fn from(value: &[u8; N]) -> Self {
+        Self {
+            data: value.to_vec(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+// BytesString <=> String/str
+
+impl<K, S> TryFrom<BoundedBytesString<K, S>> for String {
+    type Error = alloc::string::FromUtf8Error;
+
+    fn try_from(value: BoundedBytesString<K, S>) -> Result<Self, Self::Error> {
+        alloc::string::String::from_utf8(value.data)
+    }
+}
+
+impl<K, S> From<&str> for BoundedBytesString<K, S> {
+    fn from(value: &str) -> Self {
+        Self {
+            data: value.as_bytes().into(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<K, S> From<String> for BoundedBytesString<K, S> {
+    fn from(value: String) -> Self {
+        Self {
+            data: value.as_bytes().into(),
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/precompiles/utils/src/bytes.rs
+++ b/precompiles/utils/src/bytes.rs
@@ -22,8 +22,8 @@
 
 use super::*;
 use alloc::borrow::ToOwned;
-use sp_core::{ConstU32, Get};
 pub use alloc::string::String;
+use sp_core::{ConstU32, Get};
 
 type ConstU32Max = ConstU32<{ u32::MAX }>;
 

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -624,10 +624,10 @@ impl<T: EvmData, S: Get<u32>> EvmData for BoundedVec<T, S> {
             .read::<U256>()
             .map_err(|_| revert("out of bounds: length of array"))?
             .try_into()
-            .map_err(|_| revert("value too large : length of array for than max allowed"))?;
+            .map_err(|_| revert("value too large : Array has more than max items allowed"))?;
 
         if array_size > S::get() as usize {
-            return Err(revert("value too large : length of array for than max allowed").into());
+            return Err(revert("value too large : Array has more than max items allowed").into());
         }
 
         let mut array = vec![];

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -87,7 +87,7 @@ impl From<Bytes> for Vec<u8> {
 /// Provide functions to parse common types.
 #[derive(Clone, Copy, Debug)]
 pub struct EvmDataReader<'a> {
-    pub(crate) input: &'a [u8],
+    input: &'a [u8],
     cursor: usize,
 }
 
@@ -173,6 +173,11 @@ impl<'a> EvmDataReader<'a> {
             input: &self.input[offset..],
             cursor: 0,
         })
+    }
+
+    /// Return Option<&[u8]> from a given range for EvmDataReader
+    pub fn get_input_from_range(&self, range: Range<usize>) -> Option<&[u8]> {
+        self.input.get(range)
     }
 
     /// Read remaining bytes

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -87,7 +87,7 @@ impl From<Bytes> for Vec<u8> {
 /// Provide functions to parse common types.
 #[derive(Clone, Copy, Debug)]
 pub struct EvmDataReader<'a> {
-    input: &'a [u8],
+    pub(crate) input: &'a [u8],
     cursor: usize,
 }
 
@@ -173,9 +173,6 @@ impl<'a> EvmDataReader<'a> {
             input: &self.input[offset..],
             cursor: 0,
         })
-    }
-    pub fn input(&mut self) -> &[u8] {
-        self.input
     }
 
     /// Read remaining bytes

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -174,6 +174,9 @@ impl<'a> EvmDataReader<'a> {
             cursor: 0,
         })
     }
+    pub fn input(&mut self) -> &[u8] {
+        self.input
+    }
 
     /// Read remaining bytes
     pub fn read_till_end(&mut self) -> EvmResult<&[u8]> {
@@ -190,7 +193,7 @@ impl<'a> EvmDataReader<'a> {
     /// Move the reading cursor with provided length, and return a range from the previous cursor
     /// location to the new one.
     /// Checks cursor overflows.
-    fn move_cursor(&mut self, len: usize) -> EvmResult<Range<usize>> {
+    pub fn move_cursor(&mut self, len: usize) -> EvmResult<Range<usize>> {
         let start = self.cursor;
         let end = self
             .cursor
@@ -285,7 +288,7 @@ impl EvmDataWriter {
 
     /// Write arbitrary bytes.
     /// Doesn't handle any alignement checks, prefer using `write` instead if possible.
-    fn write_raw_bytes(mut self, value: &[u8]) -> Self {
+    pub fn write_raw_bytes(mut self, value: &[u8]) -> Self {
         self.data.extend_from_slice(value);
         self
     }

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -624,10 +624,10 @@ impl<T: EvmData, S: Get<u32>> EvmData for BoundedVec<T, S> {
             .read::<U256>()
             .map_err(|_| revert("out of bounds: length of array"))?
             .try_into()
-            .map_err(|_| revert("value too large : length"))?;
+            .map_err(|_| revert("value too large : length of array for than max allowed"))?;
 
         if array_size > S::get() as usize {
-            return Err(revert("value too large : length").into());
+            return Err(revert("value too large : length of array for than max allowed").into());
         }
 
         let mut array = vec![];

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -38,8 +38,8 @@ use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
 pub mod bytes;
-mod data;
-mod xcm;
+pub mod data;
+pub mod xcm;
 
 pub use data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter};
 pub use precompile_utils_macro::{generate_function_selector, keccak256};

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -37,7 +37,9 @@ use pallet_evm::{GasWeightMapping, Log};
 use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
+mod bytes;
 mod data;
+mod xcm;
 
 pub use data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter};
 pub use precompile_utils_macro::{generate_function_selector, keccak256};

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -37,7 +37,7 @@ use pallet_evm::{GasWeightMapping, Log};
 use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
-mod bytes;
+pub mod bytes;
 mod data;
 mod xcm;
 

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -511,6 +511,7 @@ fn read_bytes() {
 
     assert_eq!(data, parsed.as_bytes());
 }
+
 #[test]
 fn read_unbounded_bytes() {
     let data = b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod\

--- a/precompiles/utils/src/xcm.rs
+++ b/precompiles/utils/src/xcm.rs
@@ -312,10 +312,6 @@ impl EvmData for Junction {
     fn has_static_size() -> bool {
         false
     }
-
-    // fn signature() -> String {
-    // 	UnboundedBytes::signature()
-    // }
 }
 
 impl EvmData for Junctions {
@@ -339,10 +335,6 @@ impl EvmData for Junctions {
     fn has_static_size() -> bool {
         false
     }
-
-    // fn signature() -> String {
-    // 	Vec::<Junction>::signature()
-    // }
 }
 
 // Cannot used derive macro since it is a foreign struct.
@@ -359,8 +351,4 @@ impl EvmData for MultiLocation {
     fn has_static_size() -> bool {
         <(u8, Junctions)>::has_static_size()
     }
-
-    // fn signature() -> String {
-    // 	<(u8, Junctions)>::signature()
-    // }
 }

--- a/precompiles/utils/src/xcm.rs
+++ b/precompiles/utils/src/xcm.rs
@@ -22,6 +22,8 @@
 
 //! Encoding of XCM types for solidity
 
+use crate::Address;
+use sp_core::U256;
 use {
     crate::{bytes::*, revert, EvmData, EvmDataReader, EvmDataWriter, EvmResult},
     frame_support::{ensure, traits::ConstU32},
@@ -29,7 +31,6 @@ use {
     sp_std::vec::Vec,
     xcm::latest::{Junction, Junctions, MultiLocation, NetworkId},
 };
-
 pub const JUNCTION_SIZE_LIMIT: u32 = 2u32.pow(16);
 
 // Function to convert network id to bytes
@@ -350,5 +351,78 @@ impl EvmData for MultiLocation {
 
     fn has_static_size() -> bool {
         <(u8, Junctions)>::has_static_size()
+    }
+}
+
+pub struct EvmMultiAsset {
+    location: MultiLocation,
+    amount: U256,
+}
+
+impl EvmMultiAsset {
+    pub fn get_location(&self) -> MultiLocation {
+        self.location
+    }
+    pub fn get_amount(&self) -> U256 {
+        self.amount
+    }
+}
+impl From<(MultiLocation, U256)> for EvmMultiAsset {
+    fn from(tuple: (MultiLocation, U256)) -> Self {
+        EvmMultiAsset {
+            location: tuple.0,
+            amount: tuple.1,
+        }
+    }
+}
+impl EvmData for EvmMultiAsset {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let (location, amount) = reader.read()?;
+        Ok(EvmMultiAsset { location, amount })
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        EvmData::write(writer, (value.location, value.amount));
+    }
+
+    fn has_static_size() -> bool {
+        <(MultiLocation, U256)>::has_static_size()
+    }
+}
+
+pub struct Currency {
+    address: Address,
+    amount: U256,
+}
+
+impl Currency {
+    pub fn get_address(&self) -> Address {
+        self.address
+    }
+    pub fn get_amount(&self) -> U256 {
+        self.amount
+    }
+}
+impl From<(Address, U256)> for Currency {
+    fn from(tuple: (Address, U256)) -> Self {
+        Currency {
+            address: tuple.0,
+            amount: tuple.1,
+        }
+    }
+}
+
+impl EvmData for Currency {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let (address, amount) = reader.read()?;
+        Ok(Currency { address, amount })
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        EvmData::write(writer, (value.address, value.amount));
+    }
+
+    fn has_static_size() -> bool {
+        <(Address, U256)>::has_static_size()
     }
 }

--- a/precompiles/utils/src/xcm.rs
+++ b/precompiles/utils/src/xcm.rs
@@ -1,0 +1,362 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Encoding of XCM types for solidity
+
+use {
+    crate::{bytes::*, revert, EvmData, EvmDataReader, EvmDataWriter, EvmResult},
+    frame_support::{ensure, traits::ConstU32},
+    sp_core::H256,
+    sp_std::vec::Vec,
+    xcm::latest::{Junction, Junctions, MultiLocation, NetworkId},
+};
+
+pub const JUNCTION_SIZE_LIMIT: u32 = 2u32.pow(16);
+
+// Function to convert network id to bytes
+// We don't implement solidity::Codec here as these bytes will be appended only
+// to certain Junction variants
+// Each NetworkId variant is represented as bytes
+// The first byte represents the enum variant to be used.
+// 		- Indexes 0,2,3 represent XCM V2 variants
+// 		- Index 1 changes name in V3 (`ByGenesis`), but is compatible with V2 `Named`
+// 		- Indexes 4~10 represent new XCM V3 variants
+// The rest of the bytes (if any), represent the additional data that such enum variant requires
+// In such a case, since NetworkIds will be appended at the end, we will read the buffer until the
+// end to recover the name
+
+pub(crate) fn network_id_to_bytes(network_id: Option<NetworkId>) -> Vec<u8> {
+    let mut encoded: Vec<u8> = Vec::new();
+    match network_id.clone() {
+        None => {
+            encoded.push(0u8);
+            encoded
+        }
+        Some(NetworkId::ByGenesis(id)) => {
+            encoded.push(1u8);
+            encoded.append(&mut id.into());
+            encoded
+        }
+        Some(NetworkId::Polkadot) => {
+            encoded.push(2u8);
+            encoded.push(2u8);
+            encoded
+        }
+        Some(NetworkId::Kusama) => {
+            encoded.push(3u8);
+            encoded.push(3u8);
+            encoded
+        }
+        Some(NetworkId::ByFork {
+            block_number,
+            block_hash,
+        }) => {
+            encoded.push(4u8);
+            encoded.push(1u8);
+            encoded.append(&mut block_number.to_be_bytes().into());
+            encoded.append(&mut block_hash.into());
+            encoded
+        }
+        Some(NetworkId::Westend) => {
+            encoded.push(5u8);
+            encoded.push(4u8);
+            encoded
+        }
+        Some(NetworkId::Rococo) => {
+            encoded.push(6u8);
+            encoded.push(5u8);
+            encoded
+        }
+        Some(NetworkId::Wococo) => {
+            encoded.push(7u8);
+            encoded.push(6u8);
+            encoded
+        }
+        Some(NetworkId::Ethereum { chain_id }) => {
+            encoded.push(8u8);
+            encoded.push(7u8);
+            encoded.append(&mut chain_id.to_be_bytes().into());
+            encoded
+        }
+        Some(NetworkId::BitcoinCore) => {
+            encoded.push(9u8);
+            encoded.push(8u8);
+            encoded
+        }
+        Some(NetworkId::BitcoinCash) => {
+            encoded.push(10u8);
+            encoded.push(9u8);
+            encoded
+        }
+    }
+}
+
+// Function to convert bytes to networkId
+pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> EvmResult<Option<NetworkId>> {
+    ensure!(encoded_bytes.len() > 0, revert("Junctions cannot be empty"));
+    let mut encoded_network_id = EvmDataReader::new(&encoded_bytes);
+
+    let network_selector = encoded_network_id
+        .read_raw_bytes(1)
+        .map_err(|_| revert("network selector (1 byte)"))?;
+
+    match network_selector[0] {
+        0 => Ok(None),
+        1 => Ok(Some(NetworkId::ByGenesis(
+            encoded_network_id
+                .read_till_end()
+                .map_err(|_| revert("can't read till end"))?
+                .to_vec()
+                .try_into()
+                .map_err(|_| revert("network by genesis"))?,
+        ))),
+        2 => Ok(Some(NetworkId::Polkadot)),
+        3 => Ok(Some(NetworkId::Kusama)),
+        4 => {
+            let mut block_number: [u8; 8] = Default::default();
+            block_number.copy_from_slice(&encoded_network_id.read_raw_bytes(8)?);
+
+            let mut block_hash: [u8; 32] = Default::default();
+            block_hash.copy_from_slice(&encoded_network_id.read_raw_bytes(32)?);
+            Ok(Some(NetworkId::ByFork {
+                block_number: u64::from_be_bytes(block_number),
+                block_hash,
+            }))
+        }
+        5 => Ok(Some(NetworkId::Westend)),
+        6 => Ok(Some(NetworkId::Rococo)),
+        7 => Ok(Some(NetworkId::Wococo)),
+        8 => {
+            let mut chain_id: [u8; 8] = Default::default();
+            chain_id.copy_from_slice(&encoded_network_id.read_raw_bytes(8)?);
+            Ok(Some(NetworkId::Ethereum {
+                chain_id: u64::from_be_bytes(chain_id),
+            }))
+        }
+        9 => Ok(Some(NetworkId::BitcoinCore)),
+        10 => Ok(Some(NetworkId::BitcoinCash)),
+        _ => Err(revert("Non-valid Network Id").into()),
+    }
+}
+
+impl EvmData for Junction {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let junction = reader.read::<BoundedBytes<ConstU32<JUNCTION_SIZE_LIMIT>>>()?;
+        let junction_bytes: Vec<_> = junction.into();
+
+        ensure!(
+            junction_bytes.len() > 0,
+            revert("Junctions cannot be empty")
+        );
+
+        // For simplicity we use an EvmReader here
+        let mut encoded_junction = EvmDataReader::new(&junction_bytes);
+
+        // We take the first byte
+        let enum_selector = encoded_junction
+            .read_raw_bytes(1)
+            .map_err(|_| revert("junction variant"))?;
+
+        // The firs byte selects the enum variant
+        match enum_selector[0] {
+            0 => {
+                // In the case of Junction::Parachain, we need 4 additional bytes
+                let mut data: [u8; 4] = Default::default();
+                data.copy_from_slice(&encoded_junction.read_raw_bytes(4)?);
+                let para_id = u32::from_be_bytes(data);
+                Ok(Junction::Parachain(para_id))
+            }
+            1 => {
+                // In the case of Junction::AccountId32, we need 32 additional bytes plus NetworkId
+                let mut account: [u8; 32] = Default::default();
+                account.copy_from_slice(&encoded_junction.read_raw_bytes(32)?);
+
+                let network = encoded_junction.read_till_end()?.to_vec();
+                Ok(Junction::AccountId32 {
+                    network: network_id_from_bytes(network)?,
+                    id: account,
+                })
+            }
+            2 => {
+                // In the case of Junction::AccountIndex64, we need 8 additional bytes plus NetworkId
+                let mut index: [u8; 8] = Default::default();
+                index.copy_from_slice(&encoded_junction.read_raw_bytes(8)?);
+                // Now we read the network
+                let network = encoded_junction.read_till_end()?.to_vec();
+                Ok(Junction::AccountIndex64 {
+                    network: network_id_from_bytes(network)?,
+                    index: u64::from_be_bytes(index),
+                })
+            }
+            3 => {
+                // In the case of Junction::AccountKey20, we need 20 additional bytes plus NetworkId
+                let mut account: [u8; 20] = Default::default();
+                account.copy_from_slice(&encoded_junction.read_raw_bytes(20)?);
+
+                let network = encoded_junction.read_till_end()?.to_vec();
+                Ok(Junction::AccountKey20 {
+                    network: network_id_from_bytes(network)?,
+                    key: account,
+                })
+            }
+            4 => Ok(Junction::PalletInstance(
+                encoded_junction.read_raw_bytes(1)?[0],
+            )),
+            5 => {
+                // In the case of Junction::GeneralIndex, we need 16 additional bytes
+                let mut general_index: [u8; 16] = Default::default();
+                general_index.copy_from_slice(&encoded_junction.read_raw_bytes(16)?);
+                Ok(Junction::GeneralIndex(u128::from_be_bytes(general_index)))
+            }
+            6 => {
+                let length = encoded_junction
+                    .read_raw_bytes(1)
+                    .map_err(|_| revert("General Key length"))?[0];
+
+                let data = encoded_junction
+                    .read::<H256>()
+                    .map_err(|_| revert("can't read"))?
+                    .into();
+
+                Ok(Junction::GeneralKey { length, data })
+            }
+            7 => Ok(Junction::OnlyChild),
+            8 => Err(revert("Junction::Plurality not supported yet").into()),
+            9 => {
+                let network = encoded_junction.read_till_end()?.to_vec();
+                if let Some(network_id) = network_id_from_bytes(network)? {
+                    Ok(Junction::GlobalConsensus(network_id))
+                } else {
+                    Err(revert("Unknown NetworkId").into())
+                }
+            }
+            _ => Err(revert("Unknown Junction variant").into()),
+        }
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        let mut encoded: Vec<u8> = Vec::new();
+        let encoded_bytes: UnboundedBytes = match value {
+            Junction::Parachain(para_id) => {
+                encoded.push(0u8);
+                encoded.append(&mut para_id.to_be_bytes().to_vec());
+                encoded.as_slice().into()
+            }
+            Junction::AccountId32 { network, id } => {
+                encoded.push(1u8);
+                encoded.append(&mut id.to_vec());
+                encoded.append(&mut network_id_to_bytes(network));
+                encoded.as_slice().into()
+            }
+            Junction::AccountIndex64 { network, index } => {
+                encoded.push(2u8);
+                encoded.append(&mut index.to_be_bytes().to_vec());
+                encoded.append(&mut network_id_to_bytes(network));
+                encoded.as_slice().into()
+            }
+            Junction::AccountKey20 { network, key } => {
+                encoded.push(3u8);
+                encoded.append(&mut key.to_vec());
+                encoded.append(&mut network_id_to_bytes(network));
+                encoded.as_slice().into()
+            }
+            Junction::PalletInstance(intance) => {
+                encoded.push(4u8);
+                encoded.append(&mut intance.to_be_bytes().to_vec());
+                encoded.as_slice().into()
+            }
+            Junction::GeneralIndex(id) => {
+                encoded.push(5u8);
+                encoded.append(&mut id.to_be_bytes().to_vec());
+                encoded.as_slice().into()
+            }
+            Junction::GeneralKey { length, data } => {
+                encoded.push(6u8);
+                encoded.push(length);
+                encoded.append(&mut data.into());
+                encoded.as_slice().into()
+            }
+            Junction::OnlyChild => {
+                encoded.push(7u8);
+                encoded.as_slice().into()
+            }
+            Junction::GlobalConsensus(network_id) => {
+                encoded.push(9u8);
+                encoded.append(&mut network_id_to_bytes(Some(network_id)));
+                encoded.as_slice().into()
+            }
+            // TODO: The only missing item here is Junciton::Plurality. This is a complex encoded
+            // type that we need to evaluate how to support
+            _ => unreachable!("Junction::Plurality not supported yet"),
+        };
+        EvmData::write(writer, encoded_bytes);
+    }
+
+    fn has_static_size() -> bool {
+        false
+    }
+
+    // fn signature() -> String {
+    // 	UnboundedBytes::signature()
+    // }
+}
+
+impl EvmData for Junctions {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let junctions_bytes: Vec<Junction> = reader.read()?;
+        let mut junctions = Junctions::Here;
+        for item in junctions_bytes {
+            junctions
+                .push(item)
+                .map_err(|_| revert("overflow when reading junctions"))?;
+        }
+
+        Ok(junctions)
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        let encoded: Vec<Junction> = value.iter().map(|junction| junction.clone()).collect();
+        EvmData::write(writer, encoded);
+    }
+
+    fn has_static_size() -> bool {
+        false
+    }
+
+    // fn signature() -> String {
+    // 	Vec::<Junction>::signature()
+    // }
+}
+
+// Cannot used derive macro since it is a foreign struct.
+impl EvmData for MultiLocation {
+    fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+        let (parents, interior) = reader.read()?;
+        Ok(MultiLocation { parents, interior })
+    }
+
+    fn write(writer: &mut EvmDataWriter, value: Self) {
+        EvmData::write(writer, (value.parents, value.interior));
+    }
+
+    fn has_static_size() -> bool {
+        <(u8, Junctions)>::has_static_size()
+    }
+
+    // fn signature() -> String {
+    // 	<(u8, Junctions)>::signature()
+    // }
+}

--- a/precompiles/utils/src/xcm.rs
+++ b/precompiles/utils/src/xcm.rs
@@ -1,18 +1,24 @@
-// Copyright 2019-2022 PureStake Inc.
-// This file is part of Moonbeam.
+// This file is part of Astar.
 
-// Moonbeam is free software: you can redistribute it and/or modify
+// Copyright 2019-2022 PureStake Inc.
+// Copyright (C) 2022-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This file is part of Utils package, originally developed by Purestake Inc.
+// Utils package used in Astar Network in terms of GPLv3.
+//
+// Utils is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Moonbeam is distributed in the hope that it will be useful,
+// Utils is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU General Public License for more details.
 
 // You should have received a copy of the GNU General Public License
-// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+// along with Utils.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Encoding of XCM types for solidity
 
@@ -27,8 +33,6 @@ use {
 pub const JUNCTION_SIZE_LIMIT: u32 = 2u32.pow(16);
 
 // Function to convert network id to bytes
-// We don't implement solidity::Codec here as these bytes will be appended only
-// to certain Junction variants
 // Each NetworkId variant is represented as bytes
 // The first byte represents the enum variant to be used.
 // 		- Indexes 0,2,3 represent XCM V2 variants

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -68,4 +68,6 @@ std = [
 	"orml-xcm-support/std",
 	"orml-traits/std",
 ]
-runtime-benchmarks = []
+runtime-benchmarks = [
+	"orml-xtokens/runtime-benchmarks",
+]

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -28,6 +28,9 @@ fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
 
 # Polkadot
+orml-traits = { workspace = true }
+orml-xcm-support = { workspace = true }
+orml-xtokens = { workspace = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
 
@@ -61,5 +64,8 @@ std = [
 	"sp-io/std",
 	"xcm/std",
 	"xcm-executor/std",
+	"orml-xtokens/std",
+	"orml-xcm-support/std",
+	"orml-traits/std",
 ]
 runtime-benchmarks = []

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -61,12 +61,13 @@ interface XCM {
      * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
-        uint256 parachain_id,
+        uint256 dest_parachain_id,
         bool is_relay,
         address payment_asset_id,
         uint256 payment_amount,
         bytes calldata call,
-        uint64 transact_weight
+        uint64 transact_weight,
+        uint256 self_parachain_id
     ) external returns (bool);
 
     /**

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -4,13 +4,18 @@ pragma solidity ^0.8.0;
  * @title XCM interface.
  */
 interface XCM {
+    // A multilocation is defined by its number of parents and the encoded junctions (interior)
+    struct Multilocation {
+        uint8 parents;
+        bytes[] interior;
+    }
+    
     /**
      * @dev Withdraw assets using PalletXCM call.
      * @param asset_id - list of XC20 asset addresses
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param recipient_account_id - SS58 public key of the destination account
-     * @param is_relay - set `true` for using relay chain as reserve
-     * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
+     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
+     * @param destination - Multilocation of destination chain
      * @param fee_index - index of asset_id item that should be used as a XCM fee
      * @return bool confirmation whether the XCM message sent.
      *
@@ -21,39 +26,14 @@ interface XCM {
     function assets_withdraw(
         address[] calldata asset_id,
         uint256[] calldata asset_amount,
-        bytes32   recipient_account_id,
-        bool      is_relay,
-        uint256   parachain_id,
-        uint256   fee_index
-    ) external returns (bool);
-
-    /**
-     * @dev Withdraw assets using PalletXCM call.
-     * @param asset_id - list of XC20 asset addresses
-     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param recipient_account_id - ETH address of the destination account
-     * @param is_relay - set `true` for using relay chain as reserve
-     * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
-     * @param fee_index - index of asset_id item that should be used as a XCM fee
-     * @return bool confirmation whether the XCM message sent.
-     *
-     * How method check that assets list is valid:
-     * - all assets resolved to multi-location (on runtime level)
-     * - all assets has corresponded amount (lenght of assets list matched to amount list)
-     */
-    function assets_withdraw(
-        address[] calldata asset_id,
-        uint256[] calldata asset_amount,
-        address   recipient_account_id,
-        bool      is_relay,
-        uint256   parachain_id,
+        Multilocation memory beneficiary,
+        Multilocation memory destination,
         uint256   fee_index
     ) external returns (bool);
 
     /**
      * @dev Execute a transaction on a remote chain.
-     * @param parachain_id - destination parachain Id (ignored if is_relay is true)
-     * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
+     * @param destination - Multilocation of destination chain
      * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
      * @param payment_amount - amount of payment asset to use for execution payment - should cover cost of XCM instructions + Transact call weight.
      * @param call - encoded call data (must be decodable by remote chain)
@@ -61,8 +41,7 @@ interface XCM {
      * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
-        uint256 parachain_id,
-        bool is_relay,
+        Multilocation memory destination,
         address payment_asset_id,
         uint256 payment_amount,
         bytes calldata call,
@@ -73,12 +52,10 @@ interface XCM {
      * @dev Reserve transfer assets using PalletXCM call.
      * @param asset_id - list of XC20 asset addresses
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param recipient_account_id - SS58 public key of the destination account
-     * @param is_relay - set `true` for using relay chain as destination
-     * @param parachain_id - set parachain id of destination parachain (when is_relay set to false)
+     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
+     * @param destination - Multilocation of destination chain
      * @param fee_index - index of asset_id item that should be used as a XCM fee
      * @return A boolean confirming whether the XCM message sent.
-     *
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
@@ -86,45 +63,18 @@ interface XCM {
     function assets_reserve_transfer(
         address[] calldata asset_id,
         uint256[] calldata asset_amount,
-        bytes32   recipient_account_id,
-        bool      is_relay,
-        uint256   parachain_id,
+        Multilocation memory beneficiary,
+        Multilocation memory destination,
         uint256   fee_index
     ) external returns (bool);
 
     /**
-     * @dev Reserve transfer using PalletXCM call.
-     * @param asset_id - list of XC20 asset addresses
-     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param recipient_account_id - ETH address of the destination account
-     * @param is_relay - set `true` for using relay chain as destination
-     * @param parachain_id - set parachain id of destination parachain (when is_relay set to false)
-     * @param fee_index - index of asset_id item that should be used as a XCM fee
-     * @return A boolean confirming whether the XCM message sent.
-     *
-     * How method check that assets list is valid:
-     * - all assets resolved to multi-location (on runtime level)
-     * - all assets has corresponded amount (lenght of assets list matched to amount list)
-     */
-    function assets_reserve_transfer(
-        address[] calldata asset_id,
-        uint256[] calldata asset_amount,
-        address   recipient_account_id,
-        bool      is_relay,
-        uint256   parachain_id,
-        uint256   fee_index
-    ) external returns (bool);
-
-    /**
-     * @dev Reserve transfer using PalletXCM call.
+     * @dev send xcm using PalletXCM call.
+     * @param destination - Multilocation of destination chain where to send this call
      * @param xcm_call - encoded xcm call you want to send to destination
-     * @param is_relay - set `true` for using relay chain as destination
-     * @param destination_parachain_id - set parachain id of destination parachain (when is_relay set to false)
-     * @return A boolean confirming whether the XCM message sent.
      **/
     function send_xcm(
-        bytes memory xcm_call,
-        bool is_relay,
-        uint256 destination_parachain_id
+        Multilocation memory destination,
+        bytes memory xcm_call
     ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -114,4 +114,17 @@ interface XCM {
         uint256   parachain_id,
         uint256   fee_index
     ) external returns (bool);
+
+    /**
+     * @dev Reserve transfer using PalletXCM call.
+     * @param xcm_call - encoded xcm call you want to send to destination
+     * @param is_relay - set `true` for using relay chain as destination
+     * @param destination_parachain_id - set parachain id of destination parachain (when is_relay set to false)
+     * @return A boolean confirming whether the XCM message sent.
+     **/
+    function send_xcm(
+        bytes32  xcm_call,
+        bool is_realy,
+        uint256[] destination_parachain_id
+    ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -61,13 +61,12 @@ interface XCM {
      * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
-        uint256 dest_parachain_id,
+        uint256 parachain_id,
         bool is_relay,
         address payment_asset_id,
         uint256 payment_amount,
         bytes calldata call,
         uint64 transact_weight,
-        uint256 self_parachain_id
     ) external returns (bool);
 
     /**

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -66,7 +66,7 @@ interface XCM {
         address payment_asset_id,
         uint256 payment_amount,
         bytes calldata call,
-        uint64 transact_weight,
+        uint64 transact_weight
     ) external returns (bool);
 
     /**
@@ -124,7 +124,7 @@ interface XCM {
      **/
     function send_xcm(
         bytes32  xcm_call,
-        bool is_realy,
-        uint256[] destination_parachain_id
+        bool is_relay,
+        uint256[] calldata destination_parachain_id
     ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -1,5 +1,5 @@
  /**
- * DISCLAIMER: Please note that this file ise deprecated and users are advised to use the XCM_v2.sol file instead.
+ * DISCLAIMER: Please note that this file is deprecated and users are advised to use the XCM_v2.sol file instead.
  */
 
 pragma solidity ^0.8.0;

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -1,21 +1,21 @@
+ /**
+ * DISCLAIMER: Please note that this file ise deprecated and users are advised to use the XCM_v2.sol file instead.
+ */
+
 pragma solidity ^0.8.0;
 
 /**
  * @title XCM interface.
  */
+
 interface XCM {
-    // A multilocation is defined by its number of parents and the encoded junctions (interior)
-    struct Multilocation {
-        uint8 parents;
-        bytes[] interior;
-    }
-    
     /**
      * @dev Withdraw assets using PalletXCM call.
      * @param asset_id - list of XC20 asset addresses
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
-     * @param destination - Multilocation of destination chain
+     * @param recipient_account_id - SS58 public key of the destination account
+     * @param is_relay - set `true` for using relay chain as reserve
+     * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
      * @param fee_index - index of asset_id item that should be used as a XCM fee
      * @return bool confirmation whether the XCM message sent.
      *
@@ -26,14 +26,39 @@ interface XCM {
     function assets_withdraw(
         address[] calldata asset_id,
         uint256[] calldata asset_amount,
-        Multilocation memory beneficiary,
-        Multilocation memory destination,
+        bytes32   recipient_account_id,
+        bool      is_relay,
+        uint256   parachain_id,
+        uint256   fee_index
+    ) external returns (bool);
+
+    /**
+     * @dev Withdraw assets using PalletXCM call.
+     * @param asset_id - list of XC20 asset addresses
+     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
+     * @param recipient_account_id - ETH address of the destination account
+     * @param is_relay - set `true` for using relay chain as reserve
+     * @param parachain_id - set parachain id of reserve parachain (when is_relay set to false)
+     * @param fee_index - index of asset_id item that should be used as a XCM fee
+     * @return bool confirmation whether the XCM message sent.
+     *
+     * How method check that assets list is valid:
+     * - all assets resolved to multi-location (on runtime level)
+     * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     */
+    function assets_withdraw(
+        address[] calldata asset_id,
+        uint256[] calldata asset_amount,
+        address   recipient_account_id,
+        bool      is_relay,
+        uint256   parachain_id,
         uint256   fee_index
     ) external returns (bool);
 
     /**
      * @dev Execute a transaction on a remote chain.
-     * @param destination - Multilocation of destination chain
+     * @param parachain_id - destination parachain Id (ignored if is_relay is true)
+     * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
      * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
      * @param payment_amount - amount of payment asset to use for execution payment - should cover cost of XCM instructions + Transact call weight.
      * @param call - encoded call data (must be decodable by remote chain)
@@ -41,7 +66,8 @@ interface XCM {
      * @return bool confirmation whether the XCM message sent.
      */
     function remote_transact(
-        Multilocation memory destination,
+        uint256 parachain_id,
+        bool is_relay,
         address payment_asset_id,
         uint256 payment_amount,
         bytes calldata call,
@@ -52,10 +78,12 @@ interface XCM {
      * @dev Reserve transfer assets using PalletXCM call.
      * @param asset_id - list of XC20 asset addresses
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
-     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
-     * @param destination - Multilocation of destination chain
+     * @param recipient_account_id - SS58 public key of the destination account
+     * @param is_relay - set `true` for using relay chain as destination
+     * @param parachain_id - set parachain id of destination parachain (when is_relay set to false)
      * @param fee_index - index of asset_id item that should be used as a XCM fee
      * @return A boolean confirming whether the XCM message sent.
+     *
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
@@ -63,18 +91,32 @@ interface XCM {
     function assets_reserve_transfer(
         address[] calldata asset_id,
         uint256[] calldata asset_amount,
-        Multilocation memory beneficiary,
-        Multilocation memory destination,
+        bytes32   recipient_account_id,
+        bool      is_relay,
+        uint256   parachain_id,
         uint256   fee_index
     ) external returns (bool);
 
     /**
-     * @dev send xcm using PalletXCM call.
-     * @param destination - Multilocation of destination chain where to send this call
-     * @param xcm_call - encoded xcm call you want to send to destination
-     **/
-    function send_xcm(
-        Multilocation memory destination,
-        bytes memory xcm_call
+     * @dev Reserve transfer using PalletXCM call.
+     * @param asset_id - list of XC20 asset addresses
+     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
+     * @param recipient_account_id - ETH address of the destination account
+     * @param is_relay - set `true` for using relay chain as destination
+     * @param parachain_id - set parachain id of destination parachain (when is_relay set to false)
+     * @param fee_index - index of asset_id item that should be used as a XCM fee
+     * @return A boolean confirming whether the XCM message sent.
+     *
+     * How method check that assets list is valid:
+     * - all assets resolved to multi-location (on runtime level)
+     * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     */
+    function assets_reserve_transfer(
+        address[] calldata asset_id,
+        uint256[] calldata asset_amount,
+        address   recipient_account_id,
+        bool      is_relay,
+        uint256   parachain_id,
+        uint256   fee_index
     ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -123,7 +123,7 @@ interface XCM {
      * @return A boolean confirming whether the XCM message sent.
      **/
     function send_xcm(
-        bytes calldata xcm_call,
+        bytes memory xcm_call,
         bool is_relay,
         uint256 destination_parachain_id
     ) external returns (bool);

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -125,6 +125,6 @@ interface XCM {
     function send_xcm(
         bytes32  xcm_call,
         bool is_relay,
-        uint256[] calldata destination_parachain_id
+        uint256 destination_parachain_id
     ) external returns (bool);
 }

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -123,7 +123,7 @@ interface XCM {
      * @return A boolean confirming whether the XCM message sent.
      **/
     function send_xcm(
-        bytes32  xcm_call,
+        bytes calldata xcm_call,
         bool is_relay,
         uint256 destination_parachain_id
     ) external returns (bool);

--- a/precompiles/xcm/XCM_v2.sol
+++ b/precompiles/xcm/XCM_v2.sol
@@ -1,0 +1,80 @@
+pragma solidity ^0.8.0;
+
+/**
+ * @title XCM interface.
+ */
+interface XCM {
+    // A multilocation is defined by its number of parents and the encoded junctions (interior)
+    struct Multilocation {
+        uint8 parents;
+        bytes[] interior;
+    }
+    
+    /**
+     * @dev Withdraw assets using PalletXCM call.
+     * @param asset_id - list of XC20 asset addresses
+     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
+     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
+     * @param destination - Multilocation of destination chain
+     * @param fee_index - index of asset_id item that should be used as a XCM fee
+     * @return bool confirmation whether the XCM message sent.
+     *
+     * How method check that assets list is valid:
+     * - all assets resolved to multi-location (on runtime level)
+     * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     */
+    function assets_withdraw(
+        address[] calldata asset_id,
+        uint256[] calldata asset_amount,
+        Multilocation memory beneficiary,
+        Multilocation memory destination,
+        uint256   fee_index
+    ) external returns (bool);
+
+    /**
+     * @dev Execute a transaction on a remote chain.
+     * @param destination - Multilocation of destination chain
+     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
+     * @param payment_amount - amount of payment asset to use for execution payment - should cover cost of XCM instructions + Transact call weight.
+     * @param call - encoded call data (must be decodable by remote chain)
+     * @param transact_weight - max weight that the encoded call is allowed to consume in the destination chain
+     * @return bool confirmation whether the XCM message sent.
+     */
+    function remote_transact(
+        Multilocation memory destination,
+        address payment_asset_id,
+        uint256 payment_amount,
+        bytes calldata call,
+        uint64 transact_weight
+    ) external returns (bool);
+
+    /**
+     * @dev Reserve transfer assets using PalletXCM call.
+     * @param asset_id - list of XC20 asset addresses
+     * @param asset_amount - list of transfer amounts (must match with asset addresses above)
+     * @param beneficiary - Multilocation of beneficiary in respect to destination parachain
+     * @param destination - Multilocation of destination chain
+     * @param fee_index - index of asset_id item that should be used as a XCM fee
+     * @return A boolean confirming whether the XCM message sent.
+     * How method check that assets list is valid:
+     * - all assets resolved to multi-location (on runtime level)
+     * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     */
+    function assets_reserve_transfer(
+        address[] calldata asset_id,
+        uint256[] calldata asset_amount,
+        Multilocation memory beneficiary,
+        Multilocation memory destination,
+        uint256   fee_index
+    ) external returns (bool);
+
+    /**
+     * @dev send xcm using PalletXCM call.
+     * @param destination - Multilocation of destination chain where to send this call
+     * @param xcm_call - encoded xcm call you want to send to destination
+     **/
+    function send_xcm(
+        Multilocation memory destination,
+        bytes memory xcm_call
+    ) external returns (bool);
+}

--- a/precompiles/xcm/Xtokens.sol
+++ b/precompiles/xcm/Xtokens.sol
@@ -91,8 +91,6 @@ interface Xtokens {
     /// @param feeItem Which of the currencies to be used as fee
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain 
-    /// (uint64::MAX means Unlimited weight)
-    /// @custom:selector ab946323
     function transfer_multi_currencies(
         Currency[] memory currencies,
         uint32 feeItem,

--- a/precompiles/xcm/Xtokens.sol
+++ b/precompiles/xcm/Xtokens.sol
@@ -1,0 +1,116 @@
+
+pragma solidity ^0.8.0;
+
+
+/**
+ * @title Xtokens interface.
+ */
+interface Xtokens {
+    // A multilocation is defined by its number of parents and the encoded junctions (interior)
+    struct Multilocation {
+        uint8 parents;
+        bytes[] interior;
+    }
+
+    // A MultiAsset is defined by a multilocation and an amount
+    struct MultiAsset {
+        Multilocation location;
+        uint256 amount;
+    }
+
+    // A Currency is defined by address and the amount to be transferred
+    struct Currency {
+        address currencyAddress;
+        uint256 amount;
+    }
+
+    /// Transfer a token through XCM based on its currencyId
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param currencyAddress The ERC20 address of the currency we want to transfer
+    /// @param amount The amount of tokens we want to transfer
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    function transfer(
+        address currencyAddress,
+        uint256 amount,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+
+    /// Transfer a token through XCM based on its currencyId specifying fee
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param currencyAddress The ERC20 address of the currency we want to transfer
+    /// @param amount The amount of tokens we want to transfer
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    function transfer_with_fee(
+        address currencyAddress,
+        uint256 amount,
+        uint256 fee,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+
+    /// Transfer a token through XCM based on its MultiLocation
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param asset The asset we want to transfer, defined by its multilocation.
+    /// Currently only Concrete Fungible assets
+    /// @param amount The amount of tokens we want to transfer
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    function transfer_multiasset(
+        Multilocation memory asset,
+        uint256 amount,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+
+    /// Transfer a token through XCM based on its MultiLocation specifying fee
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param asset The asset we want to transfer, defined by its multilocation.
+    /// Currently only Concrete Fungible assets
+    /// @param amount The amount of tokens we want to transfer
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    function transfer_multiasset_with_fee(
+        Multilocation memory asset,
+        uint256 amount,
+        uint256 fee,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+
+    /// Transfer several tokens at once through XCM based on its address specifying fee
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param currencies The currencies we want to transfer, defined by their address and amount.
+    /// @param feeItem Which of the currencies to be used as fee
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    /// (uint64::MAX means Unlimited weight)
+    /// @custom:selector ab946323
+    function transfer_multi_currencies(
+        Currency[] memory currencies,
+        uint32 feeItem,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+
+    /// Transfer several tokens at once through XCM based on its location specifying fee
+    ///
+    /// @dev The token transfer burns/transfers the corresponding amount before sending
+    /// @param assets The assets we want to transfer, defined by their location and amount.
+    /// @param feeItem Which of the currencies to be used as fee
+    /// @param destination The Multilocation to which we want to send the tokens
+    /// @param weight The weight we want to buy in the destination chain 
+    function transfer_multi_assets(
+        MultiAsset[] memory assets,
+        uint32 feeItem,
+        Multilocation memory destination,
+        uint64 weight
+    ) external returns (bool);
+}

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -222,7 +222,6 @@ where
         let remote_call: Vec<u8> = input.read::<Bytes>()?.into();
         let transact_weight = input.read::<u64>()?;
         let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-        let self_para_id = input.read::<U256>()?.low_u32();
 
         log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset_addr: {:?}, \
          fee_amount: {:?}, remote_call: {:?}, transact_weight: {}",
@@ -263,6 +262,7 @@ where
         let fee_multilocation = fee_multilocation
             .reanchored(&dest, context)
             .map_err(|_| revert("Failed to reanchor fee asset"))?;
+        println!("Context {:?}",context);
 
         // Prepare XCM
         let xcm = Xcm(vec![
@@ -271,7 +271,9 @@ where
                 beneficiary: MultiLocation {
                     parents: 1,
                     interior: X2(
-                        Parachain(self_para_id),
+                        // last() returns the last Juction Enum in Junctions
+                        // for Univeral Location it is the Parachain() variant
+                        *context.last().unwrap(),
                         AccountId32 {
                             network: None,
                             id: origin.into(),

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -34,7 +34,7 @@ use sp_core::{H160, H256, U256};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 
-use xcm::{latest::prelude::*, VersionedMultiLocation};
+use xcm::{latest::prelude::*, VersionedMultiAsset, VersionedMultiLocation};
 use xcm_executor::traits::Convert;
 
 use pallet_evm_precompile_assets_erc20::AddressToAssetId;
@@ -63,8 +63,9 @@ pub enum Action {
         "assets_reserve_transfer(address[],uint256[],(uint8,bytes[]),(uint8,bytes[]),uint256)",
     SendXCM = "send_xcm((uint8,bytes[]),bytes)",
     XtokensTransfer = "transfer(address,uint256,(uint8,bytes[]),uint64)",
-    //     XtokensTransferWithFee = "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),uint64)",
-    //     XtokensTransferMultiasset = "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),uint64)",
+    XtokensTransferWithFee = "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),uint64)",
+    XtokensTransferMultiasset =
+        "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),uint64)",
     //     XtokensTransferMultiassetWithFee = "transfer_multiasset_with_fee((uint8,bytes[]),uint256,uint256,(uint8,bytes[]),uint64)",
     //     XtokensTransferMulticurrencies = "transfer_multi_currencies((address,uint256)[],uint32,(uint8,bytes[]),uint64)",
     //     XtokensTransferMultiassets = "transfet_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),uint64)",
@@ -125,6 +126,8 @@ where
             Action::AssetsReserveTransfer => Self::assets_reserve_transfer(handle),
             Action::SendXCM => Self::send_xcm(handle),
             Action::XtokensTransfer => Self::transfer(handle),
+            Action::XtokensTransferWithFee => Self::transfer_with_fee(handle),
+            Action::XtokensTransferMultiasset => Self::transfer_multiasset(handle),
         }
     }
 }
@@ -694,6 +697,90 @@ where
         let call = orml_xtokens::Call::<Runtime>::transfer {
             currency_id: asset_id.into(),
             amount: amount_of_tokens,
+            dest: Box::new(VersionedMultiLocation::V3(destination)),
+            dest_weight_limit,
+        };
+
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+
+        // Dispatch a call.
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
+    fn transfer_with_fee(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(6)?;
+
+        // Read call arguments
+        let currency_address = input.read::<Address>()?;
+        let amount_of_tokens = input
+            .read::<U256>()?
+            .try_into()
+            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
+        let fee = input
+            .read::<U256>()?
+            .try_into()
+            .map_err(|_| revert("can't convert fee"))?;
+
+        let destination = input.read::<MultiLocation>()?;
+        let weight = input.read::<u64>()?;
+
+        let asset_id = Runtime::address_to_asset_id(currency_address.into())
+            .ok_or(revert("Failed to resolve fee asset id from address"))?;
+        let dest_weight_limit = if weight == u64::MAX {
+            WeightLimit::Unlimited
+        } else {
+            WeightLimit::Limited(Weight::from_parts(weight, DEFAULT_PROOF_SIZE))
+        };
+
+        let call = orml_xtokens::Call::<Runtime>::transfer_with_fee {
+            currency_id: asset_id.into(),
+            amount: amount_of_tokens,
+            fee,
+            dest: Box::new(VersionedMultiLocation::V3(destination)),
+            dest_weight_limit,
+        };
+
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+
+        // Dispatch a call.
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
+    fn transfer_multiasset(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(5)?;
+
+        // Read call arguments
+        let asset_location = input.read::<MultiLocation>()?;
+        let amount_of_tokens = input
+            .read::<U256>()?
+            .try_into()
+            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
+        let destination = input.read::<MultiLocation>()?;
+        let weight = input.read::<u64>()?;
+
+        let dest_weight_limit = if weight == u64::MAX {
+            WeightLimit::Unlimited
+        } else {
+            WeightLimit::Limited(Weight::from_parts(weight, DEFAULT_PROOF_SIZE))
+        };
+
+        let call = orml_xtokens::Call::<Runtime>::transfer_multiasset {
+            asset: Box::new(VersionedMultiAsset::V3(MultiAsset {
+                id: AssetId::Concrete(asset_location),
+                fun: Fungibility::Fungible(amount_of_tokens),
+            })),
             dest: Box::new(VersionedMultiLocation::V3(destination)),
             dest_weight_limit,
         };

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -225,21 +225,6 @@ where
                 fees: fee_multilocation.clone().into(),
                 weight_limit: WeightLimit::Unlimited,
             },
-            SetAppendix(Xcm(vec![DepositAsset {
-                assets: All.into(),
-                beneficiary: MultiLocation {
-                    parents: 1,
-                    interior: X2(
-                        // last() returns the last Juction Enum in Junctions
-                        // for Univeral Location it is the Parachain() variant
-                        *context.last().unwrap(),
-                        AccountId32 {
-                            network: None,
-                            id: origin.into(),
-                        },
-                    ),
-                },
-            }])),
             Transact {
                 origin_kind: OriginKind::SovereignAccount,
                 require_weight_at_most: Weight::from_ref_time(transact_weight),

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -423,7 +423,7 @@ where
         let is_relay = input.read::<bool>()?;
         let dest_para_id: u32 = input.read::<U256>()?.low_u32();
         
-        log::trace!(target:"xcm-precompile:send_xcm", "Raw arguments: xcm_call: {:?}, is_relay: {}, destination_parachain_id: {:?}", xcm_call, is_relay,dest_para_id);
+        log::trace!(target:"xcm-send_xcm", "Raw arguments: xcm_call: {:?}, is_relay: {}, destination_parachain_id: {:?}", xcm_call, is_relay,dest_para_id);
         
         let xcm_call: Vec<_> = xcm_call.to_vec();
 
@@ -450,7 +450,7 @@ where
             dest: Box::new(dest.into()),
             message: Box::new(xcm),
         };
-        log::trace!(target: "xcm-precompile:send_xcm", "Processed arguments:  XCM call: {:?}", call);
+        log::trace!(target: "xcm-send_xcm", "Processed arguments:  XCM call: {:?}", call);
         // Dispatch a call.
         RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
 

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -262,7 +262,6 @@ where
         let fee_multilocation = fee_multilocation
             .reanchored(&dest, context)
             .map_err(|_| revert("Failed to reanchor fee asset"))?;
-        println!("Context {:?}",context);
 
         // Prepare XCM
         let xcm = Xcm(vec![

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -270,6 +270,11 @@ where
 
         // Prepare XCM
         let xcm = Xcm(vec![
+            WithdrawAsset(fee_multilocation.clone().into()),
+            BuyExecution {
+                fees: fee_multilocation.clone().into(),
+                weight_limit: WeightLimit::Unlimited,
+            },
             SetAppendix(Xcm(vec![DepositAsset {
                 assets: All.into(),
                 beneficiary: MultiLocation {
@@ -285,11 +290,6 @@ where
                     ),
                 },
             }])),
-            WithdrawAsset(fee_multilocation.clone().into()),
-            BuyExecution {
-                fees: fee_multilocation.clone().into(),
-                weight_limit: WeightLimit::Unlimited,
-            },
             Transact {
                 origin_kind: OriginKind::SovereignAccount,
                 require_weight_at_most: Weight::from_ref_time(transact_weight),

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -422,6 +422,10 @@ where
         let xcm_call : Vec<u8> = input.read::<Bytes>()?.into();
         let is_relay = input.read::<bool>()?;
         let dest_para_id: u32 = input.read::<U256>()?.low_u32();
+        
+        log::trace!(target:"xcm-precompile:send_xcm", "Raw arguments: xcm_call: {:?}, is_relay: {}, destination_parachain_id: {:?}", xcm_call, is_relay,dest_para_id);
+        
+        let xcm_call: Vec<_> = xcm_call.to_vec();
 
         let xcm = xcm::VersionedXcm::<()>::decode_all_with_depth_limit(
 			xcm::MAX_XCM_DECODE_DEPTH,
@@ -430,7 +434,6 @@ where
             revert("Failed to decode xcm instructions")
         })?;
 
-        log::trace!(target: "xcm-precompile:send_xcm", "Raw arguments: xcm_call: {:?}, is_relay: {}, destination_parachain_id: {:?}", xcm_call, is_relay,dest_para_id);
 
         let dest = if is_relay {
             MultiLocation::parent()

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -61,18 +61,18 @@ const NATIVE_ADDRESS: H160 = H160::zero();
 /// A precompile that expose XCM related functions.
 pub struct XcmPrecompile<T, C>(PhantomData<(T, C)>);
 
-impl<R, C> Precompile for XcmPrecompile<R, C>
+impl<Runtime, C> Precompile for XcmPrecompile<Runtime, C>
 where
-    R: pallet_evm::Config
+    Runtime: pallet_evm::Config
         + pallet_xcm::Config
         + pallet_assets::Config
-        + AddressToAssetId<<R as pallet_assets::Config>::AssetId>,
-    <<R as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
-        From<Option<R::AccountId>>,
-    <R as frame_system::Config>::AccountId: Into<[u8; 32]>,
-    <R as frame_system::Config>::RuntimeCall:
-        From<pallet_xcm::Call<R>> + Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
-    C: Convert<MultiLocation, <R as pallet_assets::Config>::AssetId>,
+        + AddressToAssetId<<Runtime as pallet_assets::Config>::AssetId>,
+    <<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
+        From<Option<Runtime::AccountId>>,
+    <Runtime as frame_system::Config>::AccountId: Into<[u8; 32]>,
+    <Runtime as frame_system::Config>::RuntimeCall:
+        From<pallet_xcm::Call<Runtime>> + Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+    C: Convert<MultiLocation, <Runtime as pallet_assets::Config>::AssetId>,
 {
     fn execute(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
         log::trace!(target: "xcm-precompile", "In XCM precompile");

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -30,7 +30,7 @@ type GetXcmSizeLimit = ConstU32<XCM_SIZE_LIMIT>;
 
 use pallet_evm::{AddressMapping, Precompile};
 use parity_scale_codec::DecodeLimit;
-use sp_core::{H160, U256};
+use sp_core::{H160, H256, U256};
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 
@@ -50,8 +50,15 @@ mod tests;
 #[precompile_utils::generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
+    AssetsWithdrawNative = "assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)",
+    AssetsWithdrawEvm = "assets_withdraw(address[],uint256[],address,bool,uint256,uint256)",
+    RemoteTransactOld = "remote_transact(uint256,bool,address,uint256,bytes,uint64)",
+    AssetsReserveTransferNative =
+        "assets_reserve_transfer(address[],uint256[],bytes32,bool,uint256,uint256)",
+    AssetsReserveTransferEvm =
+        "assets_reserve_transfer(address[],uint256[],address,bool,uint256,uint256)",
     AssetsWithdraw = "assets_withdraw(address[],uint256[],(uint8,bytes[]),(uint8,bytes[]),uint256)",
-    RemoteTransact = "remote_transact((uint8,bytes[]),address,uint256,bytes,uint64)",
+    RemoteTransactNew = "remote_transact((uint8,bytes[]),address,uint256,bytes,uint64)",
     AssetsReserveTransfer =
         "assets_reserve_transfer(address[],uint256[],(uint8,bytes[]),(uint8,bytes[]),uint256)",
     SendXCM = "send_xcm((uint8,bytes[]),bytes)",
@@ -86,12 +93,33 @@ where
 
         // Dispatch the call
         match selector {
+            Action::AssetsWithdrawNative => {
+                Self::assets_withdraw_v1(handle, BeneficiaryType::Account32)
+            }
+            Action::AssetsWithdrawEvm => {
+                Self::assets_withdraw_v1(handle, BeneficiaryType::Account20)
+            }
+            Action::RemoteTransactOld => Self::remote_transact_v1(handle),
+            Action::AssetsReserveTransferNative => {
+                Self::assets_reserve_transfer_v1(handle, BeneficiaryType::Account32)
+            }
+            Action::AssetsReserveTransferEvm => {
+                Self::assets_reserve_transfer_v1(handle, BeneficiaryType::Account20)
+            }
             Action::AssetsWithdraw => Self::assets_withdraw(handle),
-            Action::RemoteTransact => Self::remote_transact(handle),
+            Action::RemoteTransactNew => Self::remote_transact(handle),
             Action::AssetsReserveTransfer => Self::assets_reserve_transfer(handle),
             Action::SendXCM => Self::send_xcm(handle),
         }
     }
+}
+
+/// The supported beneficiary account types
+enum BeneficiaryType {
+    /// 256 bit (32 byte) public key
+    Account32,
+    /// 160 bit (20 byte) address is expected
+    Account20,
 }
 
 impl<Runtime, C> XcmPrecompile<Runtime, C>
@@ -108,6 +136,277 @@ where
         + GetDispatchInfo,
     C: Convert<MultiLocation, <Runtime as pallet_assets::Config>::AssetId>,
 {
+    fn assets_withdraw_v1(
+        handle: &mut impl PrecompileHandle,
+        beneficiary_type: BeneficiaryType,
+    ) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(6)?;
+
+        // Read arguments and check it
+        let assets: Vec<MultiLocation> = input
+            .read::<Vec<Address>>()?
+            .iter()
+            .cloned()
+            .filter_map(|address| {
+                Runtime::address_to_asset_id(address.into()).and_then(|x| C::reverse_ref(x).ok())
+            })
+            .collect();
+        let amounts_raw = input.read::<Vec<U256>>()?;
+        if amounts_raw.iter().any(|x| *x > u128::MAX.into()) {
+            return Err(revert("Asset amount is too big"));
+        }
+        let amounts: Vec<u128> = amounts_raw.iter().map(|x| x.low_u128()).collect();
+
+        // Check that assets list is valid:
+        // * all assets resolved to multi-location
+        // * all assets has corresponded amount
+        if assets.len() != amounts.len() || assets.is_empty() {
+            return Err(revert("Assets resolution failure."));
+        }
+
+        let beneficiary: MultiLocation = match beneficiary_type {
+            BeneficiaryType::Account32 => {
+                let recipient: [u8; 32] = input.read::<H256>()?.into();
+                X1(Junction::AccountId32 {
+                    network: None,
+                    id: recipient,
+                })
+            }
+            BeneficiaryType::Account20 => {
+                let recipient: H160 = input.read::<Address>()?.into();
+                X1(Junction::AccountKey20 {
+                    network: None,
+                    key: recipient.to_fixed_bytes(),
+                })
+            }
+        }
+        .into();
+
+        let is_relay = input.read::<bool>()?;
+        let parachain_id: u32 = input.read::<U256>()?.low_u32();
+        let fee_asset_item: u32 = input.read::<U256>()?.low_u32();
+
+        if fee_asset_item as usize > assets.len() {
+            return Err(revert("Bad fee index."));
+        }
+
+        // Prepare pallet-xcm call arguments
+        let dest = if is_relay {
+            MultiLocation::parent()
+        } else {
+            X1(Junction::Parachain(parachain_id)).into_exterior(1)
+        };
+
+        let assets: MultiAssets = assets
+            .iter()
+            .cloned()
+            .zip(amounts.iter().cloned())
+            .map(Into::into)
+            .collect::<Vec<MultiAsset>>()
+            .into();
+
+        // Build call with origin.
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+        let call = pallet_xcm::Call::<Runtime>::reserve_withdraw_assets {
+            dest: Box::new(dest.into()),
+            beneficiary: Box::new(beneficiary.into()),
+            assets: Box::new(assets.into()),
+            fee_asset_item,
+        };
+
+        // Dispatch a call.
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
+    fn remote_transact_v1(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(6)?;
+
+        // Raw call arguments
+        let para_id: u32 = input.read::<U256>()?.low_u32();
+        let is_relay = input.read::<bool>()?;
+
+        let fee_asset_addr = input.read::<Address>()?;
+        let fee_amount = input.read::<U256>()?;
+
+        let remote_call: Vec<u8> = input.read::<Bytes>()?.into();
+        let transact_weight = input.read::<u64>()?;
+
+        log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset_addr: {:?}, \
+         fee_amount: {:?}, remote_call: {:?}, transact_weight: {}",
+        para_id, is_relay, fee_asset_addr, fee_amount, remote_call, transact_weight);
+
+        // Process arguments
+        let dest = if is_relay {
+            MultiLocation::parent()
+        } else {
+            X1(Junction::Parachain(para_id)).into_exterior(1)
+        };
+
+        let fee_asset = {
+            let address: H160 = fee_asset_addr.into();
+
+            // Special case where zero address maps to native token by convention.
+            if address == NATIVE_ADDRESS {
+                Here.into()
+            } else {
+                let fee_asset_id = Runtime::address_to_asset_id(address)
+                    .ok_or(revert("Failed to resolve fee asset id from address"))?;
+                C::reverse_ref(fee_asset_id).map_err(|_| {
+                    revert("Failed to resolve fee asset multilocation from local id")
+                })?
+            }
+        };
+
+        if fee_amount > u128::MAX.into() {
+            return Err(revert("Fee amount is too big"));
+        }
+        let fee_amount = fee_amount.low_u128();
+
+        let context = Runtime::UniversalLocation::get();
+        let fee_multilocation = MultiAsset {
+            id: Concrete(fee_asset),
+            fun: Fungible(fee_amount),
+        };
+        let fee_multilocation = fee_multilocation
+            .reanchored(&dest, context)
+            .map_err(|_| revert("Failed to reanchor fee asset"))?;
+
+        // Prepare XCM
+        let xcm = Xcm(vec![
+            WithdrawAsset(fee_multilocation.clone().into()),
+            BuyExecution {
+                fees: fee_multilocation.clone().into(),
+                weight_limit: WeightLimit::Unlimited,
+            },
+            Transact {
+                origin_kind: OriginKind::SovereignAccount,
+                require_weight_at_most: Weight::from_ref_time(transact_weight),
+                call: remote_call.into(),
+            },
+        ]);
+
+        log::trace!(target: "xcm-precompile:remote_transact", "Processed arguments: dest: {:?}, fee asset: {:?}, XCM: {:?}", dest, fee_multilocation, xcm);
+
+        // Build call with origin.
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+        let call = pallet_xcm::Call::<Runtime>::send {
+            dest: Box::new(dest.into()),
+            message: Box::new(xcm::VersionedXcm::V3(xcm)),
+        };
+
+        // Dispatch a call.
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
+    fn assets_reserve_transfer_v1(
+        handle: &mut impl PrecompileHandle,
+        beneficiary_type: BeneficiaryType,
+    ) -> EvmResult<PrecompileOutput> {
+        let mut input = handle.read_input()?;
+        input.expect_arguments(6)?;
+
+        // Read arguments and check it
+        let assets: Vec<MultiLocation> = input
+            .read::<Vec<Address>>()?
+            .iter()
+            .cloned()
+            .filter_map(|address| {
+                let address: H160 = address.into();
+
+                // Special case where zero address maps to native token by convention.
+                if address == NATIVE_ADDRESS {
+                    Some(Here.into())
+                } else {
+                    Runtime::address_to_asset_id(address).and_then(|x| C::reverse_ref(x).ok())
+                }
+            })
+            .collect();
+        let amounts_raw = input.read::<Vec<U256>>()?;
+        if amounts_raw.iter().any(|x| *x > u128::MAX.into()) {
+            return Err(revert("Asset amount is too big"));
+        }
+        let amounts: Vec<u128> = amounts_raw.iter().map(|x| x.low_u128()).collect();
+
+        log::trace!(target: "xcm-precompile:assets_reserve_transfer", "Processed arguments: assets {:?}, amounts: {:?}", assets, amounts);
+
+        // Check that assets list is valid:
+        // * all assets resolved to multi-location
+        // * all assets has corresponded amount
+        if assets.len() != amounts.len() || assets.is_empty() {
+            return Err(revert("Assets resolution failure."));
+        }
+
+        let beneficiary: MultiLocation = match beneficiary_type {
+            BeneficiaryType::Account32 => {
+                let recipient: [u8; 32] = input.read::<H256>()?.into();
+                X1(Junction::AccountId32 {
+                    network: None,
+                    id: recipient,
+                })
+            }
+            BeneficiaryType::Account20 => {
+                let recipient: H160 = input.read::<Address>()?.into();
+                X1(Junction::AccountKey20 {
+                    network: None,
+                    key: recipient.to_fixed_bytes(),
+                })
+            }
+        }
+        .into();
+
+        let is_relay = input.read::<bool>()?;
+        let parachain_id: u32 = input.read::<U256>()?.low_u32();
+        let fee_asset_item: u32 = input.read::<U256>()?.low_u32();
+
+        if fee_asset_item as usize > assets.len() {
+            return Err(revert("Bad fee index."));
+        }
+
+        // Prepare pallet-xcm call arguments
+        let dest = if is_relay {
+            MultiLocation::parent()
+        } else {
+            X1(Junction::Parachain(parachain_id)).into_exterior(1)
+        };
+
+        let assets: MultiAssets = assets
+            .iter()
+            .cloned()
+            .zip(amounts.iter().cloned())
+            .map(Into::into)
+            .collect::<Vec<MultiAsset>>()
+            .into();
+
+        // Build call with origin.
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+        let call = pallet_xcm::Call::<Runtime>::reserve_transfer_assets {
+            dest: Box::new(dest.into()),
+            beneficiary: Box::new(beneficiary.into()),
+            assets: Box::new(assets.into()),
+            fee_asset_item,
+        };
+
+        // Dispatch a call.
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call)?;
+
+        Ok(succeed(EvmDataWriter::new().write(true).build()))
+    }
+
     fn assets_withdraw(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
         let mut input = handle.read_input()?;
         input.expect_arguments(6)?;
@@ -183,7 +482,6 @@ where
 
         let remote_call: Vec<u8> = input.read::<Bytes>()?.into();
         let transact_weight = input.read::<u64>()?;
-        let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 
         log::trace!(target: "xcm-precompile::remote_transact", "Raw arguments: dest: {:?}, fee_asset_addr: {:?} \
          fee_amount: {:?}, remote_call: {:?}, transact_weight: {}",

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -182,18 +182,18 @@ impl frame_system::Config for Runtime {
 #[derive(Debug, Clone, Copy)]
 pub struct TestPrecompileSet<R>(PhantomData<R>);
 
-impl<R> PrecompileSet for TestPrecompileSet<R>
+impl<Runtime> PrecompileSet for TestPrecompileSet<Runtime>
 where
-    R: pallet_evm::Config
+    Runtime: pallet_evm::Config
         + pallet_xcm::Config
         + pallet_assets::Config
-        + AddressToAssetId<<R as pallet_assets::Config>::AssetId>,
-    XcmPrecompile<R, AssetIdConverter<AssetId>>: Precompile,
+        + AddressToAssetId<<Runtime as pallet_assets::Config>::AssetId>,
+    XcmPrecompile<Runtime, AssetIdConverter<AssetId>>: Precompile,
 {
     fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
         match handle.code_address() {
             a if a == PRECOMPILE_ADDRESS => Some(
-                XcmPrecompile::<R, AssetIdConverter<AssetId>>::execute(handle),
+                XcmPrecompile::<Runtime, AssetIdConverter<AssetId>>::execute(handle),
             ),
             _ => None,
         }
@@ -312,9 +312,9 @@ impl pallet_evm::Config for Runtime {
 }
 
 parameter_types! {
-    pub const RelayLocation: MultiLocation = Here.into_location();
+    pub RelayNetwork: Option<NetworkId> = Some(NetworkId::Polkadot);
     pub const AnyNetwork: Option<NetworkId> = None;
-    pub UniversalLocation: InteriorMultiLocation = Here;
+    pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(RelayNetwork::get().unwrap()), Parachain(123));
     pub Ancestry: MultiLocation = Here.into();
     pub UnitWeightCost: u64 = 1_000;
     pub const MaxAssetsIntoHolding: u32 = 64;

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -192,9 +192,9 @@ where
 {
     fn execute(&self, handle: &mut impl PrecompileHandle) -> Option<PrecompileResult> {
         match handle.code_address() {
-            a if a == PRECOMPILE_ADDRESS => Some(
-                XcmPrecompile::<Runtime, AssetIdConverter<AssetId>>::execute(handle),
-            ),
+            a if a == PRECOMPILE_ADDRESS => {
+                Some(XcmPrecompile::<Runtime, AssetIdConverter<AssetId>>::execute(handle))
+            }
             _ => None,
         }
     }

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -31,351 +31,608 @@ fn precompiles() -> TestPrecompileSet<Runtime> {
     PrecompilesValue::get()
 }
 
-#[test]
-fn wrong_assets_len_or_fee_index_reverts() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest: MultiLocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::X1(Junction::Parachain(2000u32)),
-        };
+mod xcm_old_interface_test {
+    use super::*;
+    #[test]
+    fn wrong_assets_len_or_fee_index_reverts() {
+        ExtBuilder::default().build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
+                        .write(vec![Address::from(H160::repeat_byte(0xF1))])
+                        .write(Vec::<U256>::new())
+                        .write(H256::repeat_byte(0xF1))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Assets resolution failure.");
 
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountId32 {
-                network: None,
-                id: H256::repeat_byte(0xF1).into(),
-            }),
-        };
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
-                    .write(vec![Address::from(H160::repeat_byte(0xF1))])
-                    .write(Vec::<U256>::new())
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_reverts(|output| output == b"Assets resolution failure.");
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(H256::repeat_byte(0xF1))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(2_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Bad fee index.");
+        });
+    }
 
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
-                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(2_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_reverts(|output| output == b"Bad fee index.");
-    });
-}
+    #[test]
+    fn assets_withdraw_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdrawNative)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(H256::repeat_byte(0xF1))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
 
-#[test]
-fn assets_withdraw_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest: MultiLocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::Here,
-        };
+            // H160
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdrawEvm)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(Address::from(H160::repeat_byte(0xDE)))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+    }
 
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountId32 {
-                network: None,
-                id: H256::repeat_byte(0xF1).into(),
-            }),
-        };
+    #[test]
+    fn remote_transact_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::RemoteTransactOld)
+                        .write(U256::from(0_u64))
+                        .write(true)
+                        .write(Address::from(Runtime::asset_id_to_address(1_u128)))
+                        .write(U256::from(367))
+                        .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
+                        .write(U256::from(3_000_000_000u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+    }
 
-        // SS58
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
-                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
+    #[test]
+    fn reserve_transfer_assets_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransferNative)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(H256::repeat_byte(0xF1))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
 
-        // H160
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountKey20 {
-                network: None,
-                key: H160::repeat_byte(0xDE).into(),
-            }),
-        };
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
-                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-    });
-}
+            // H160
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransferEvm)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(Address::from(H160::repeat_byte(0xDE)))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
 
-#[test]
-fn remote_transact_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        let multilocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::X1(Junction::Parachain(2000u32)),
-        };
-        // SS58
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::RemoteTransact)
-                    .write(multilocation)
-                    .write(Address::from(Runtime::asset_id_to_address(1_u128)))
-                    .write(U256::from(367))
-                    .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
-                    .write(U256::from(3_000_000_000u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-    });
-}
-
-#[test]
-fn reserve_transfer_assets_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest: MultiLocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::Here,
-        };
-
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountId32 {
-                network: None,
-                id: H256::repeat_byte(0xF1).into(),
-            }),
-        };
-        // SS58
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
-                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-
-        // H160
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountKey20 {
-                network: None,
-                key: H160::repeat_byte(0xDE).into(),
-            }),
-        };
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
-                    .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-    });
-
-    for (location, Xcm(instructions)) in take_sent_xcm() {
-        assert_eq!(
-            location,
-            MultiLocation {
-                parents: 1,
-                interior: Here
-            }
-        );
-
-        let non_native_asset = MultiAsset {
-            fun: Fungible(42000),
-            id: xcm::v3::AssetId::from(MultiLocation {
-                parents: 0,
-                interior: Here,
-            }),
-        };
-
-        assert_matches!(
-            instructions.as_slice(),
-            [
-                ReserveAssetDeposited(assets),
-                ClearOrigin,
-                BuyExecution {
-                    fees,
-                    ..
-                },
-                DepositAsset {
-                    beneficiary: MultiLocation {
-                        parents: 0,
-                        interior: X1(_),
-                    },
-                    ..
+        for (location, Xcm(instructions)) in take_sent_xcm() {
+            assert_eq!(
+                location,
+                MultiLocation {
+                    parents: 1,
+                    interior: Here
                 }
-            ]
+            );
 
-            if fees.contains(&non_native_asset) && assets.contains(&non_native_asset)
-        );
+            let non_native_asset = MultiAsset {
+                fun: Fungible(42000),
+                id: xcm::v3::AssetId::from(MultiLocation {
+                    parents: 0,
+                    interior: Here,
+                }),
+            };
+
+            assert_matches!(
+                instructions.as_slice(),
+                [
+                    ReserveAssetDeposited(assets),
+                    ClearOrigin,
+                    BuyExecution {
+                        fees,
+                        ..
+                    },
+                    DepositAsset {
+                        beneficiary: MultiLocation {
+                            parents: 0,
+                            interior: X1(_),
+                        },
+                        ..
+                    }
+                ]
+
+                if fees.contains(&non_native_asset) && assets.contains(&non_native_asset)
+            );
+        }
+    }
+
+    #[test]
+    fn reserve_transfer_currency_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransferNative)
+                        .write(vec![Address::from(H160::zero())]) // zero address by convention
+                        .write(vec![U256::from(42000u64)])
+                        .write(H256::repeat_byte(0xF1))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransferEvm)
+                        .write(vec![Address::from(H160::zero())]) // zero address by convention
+                        .write(vec![U256::from(42000u64)])
+                        .write(Address::from(H160::repeat_byte(0xDE)))
+                        .write(true)
+                        .write(U256::from(0_u64))
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+
+        for (location, Xcm(instructions)) in take_sent_xcm() {
+            assert_eq!(
+                location,
+                MultiLocation {
+                    parents: 1,
+                    interior: Here
+                }
+            );
+
+            let native_asset = MultiAsset {
+                fun: Fungible(42000),
+                id: xcm::v3::AssetId::from(MultiLocation {
+                    parents: 0,
+                    interior: X1(Parachain(123)),
+                }),
+            };
+
+            assert_matches!(
+                instructions.as_slice(),
+                [
+                    ReserveAssetDeposited(assets),
+                    ClearOrigin,
+                    BuyExecution {
+                        fees,
+                        ..
+                    },
+                    DepositAsset {
+                        beneficiary: MultiLocation {
+                            parents: 0,
+                            interior: X1(_),
+                        },
+                        ..
+                    }
+                ]
+
+                if fees.contains(&native_asset) && assets.contains(&native_asset)
+            );
+        }
     }
 }
-
-#[test]
-fn reserve_transfer_currency_works() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest: MultiLocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::Here,
-        };
-
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountId32 {
-                network: None,
-                id: H256::repeat_byte(0xF1).into(),
-            }),
-        };
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
-                    .write(vec![Address::from(H160::zero())]) // zero address by convention
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-
-        let beneficiary: MultiLocation = MultiLocation {
-            parents: 0,
-            interior: Junctions::X1(AccountKey20 {
-                network: None,
-                key: H160::repeat_byte(0xDE).into(),
-            }),
-        };
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
-                    .write(vec![Address::from(H160::zero())]) // zero address by convention
-                    .write(vec![U256::from(42000u64)])
-                    .write(beneficiary)
-                    .write(dest)
-                    .write(U256::from(0_u64))
-                    .build(),
-            )
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
-    });
-
-    for (location, Xcm(instructions)) in take_sent_xcm() {
-        assert_eq!(
-            location,
-            MultiLocation {
+mod xcm_new_interface_test {
+    use super::*;
+    #[test]
+    fn wrong_assets_len_or_fee_index_reverts() {
+        ExtBuilder::default().build().execute_with(|| {
+            let dest: MultiLocation = MultiLocation {
                 parents: 1,
-                interior: Here
-            }
-        );
+                interior: Junctions::X1(Junction::Parachain(2000u32)),
+            };
 
-        let native_asset = MultiAsset {
-            fun: Fungible(42000),
-            id: xcm::v3::AssetId::from(MultiLocation {
+            let beneficiary: MultiLocation = MultiLocation {
                 parents: 0,
-                interior: X1(Parachain(123)),
-            }),
-        };
+                interior: Junctions::X1(AccountId32 {
+                    network: None,
+                    id: H256::repeat_byte(0xF1).into(),
+                }),
+            };
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                        .write(vec![Address::from(H160::repeat_byte(0xF1))])
+                        .write(Vec::<U256>::new())
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Assets resolution failure.");
 
-        assert_matches!(
-            instructions.as_slice(),
-            [
-                ReserveAssetDeposited(assets),
-                ClearOrigin,
-                BuyExecution {
-                    fees,
-                    ..
-                },
-                DepositAsset {
-                    beneficiary: MultiLocation {
-                        parents: 0,
-                        interior: X1(_),
-                    },
-                    ..
-                }
-            ]
-
-            if fees.contains(&native_asset) && assets.contains(&native_asset)
-        );
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(2_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Bad fee index.");
+        });
     }
-}
 
-#[test]
-fn test_send_clear_origin() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest: MultiLocation = MultiLocation {
-            parents: 1,
-            interior: Junctions::X1(Junction::AccountId32 {
-                network: None,
-                id: H256::repeat_byte(0xF1).into(),
-            }),
-        };
-        let xcm_to_send = VersionedXcm::<()>::V3(Xcm(vec![ClearOrigin])).encode();
-        precompiles()
-            .prepare_test(
-                TestAccount::Alice,
-                PRECOMPILE_ADDRESS,
-                EvmDataWriter::new_with_selector(Action::SendXCM)
-                    .write(dest)
-                    .write(Bytes::from(xcm_to_send.as_slice()))
-                    .build(),
-            )
-            // Fixed: TestWeightInfo + (BaseXcmWeight * MessageLen)
-            .expect_cost(100001000)
-            .expect_no_logs()
-            .execute_returns(EvmDataWriter::new().write(true).build());
+    #[test]
+    fn assets_withdraw_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            let dest: MultiLocation = MultiLocation {
+                parents: 1,
+                interior: Junctions::Here,
+            };
 
-        let sent_messages = take_sent_xcm();
-        let (_, sent_message) = sent_messages.first().unwrap();
-        // Lets make sure the message is as expected
-        assert!(sent_message.0.contains(&ClearOrigin));
-    })
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountId32 {
+                    network: None,
+                    id: H256::repeat_byte(0xF1).into(),
+                }),
+            };
+
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+
+            // H160
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountKey20 {
+                    network: None,
+                    key: H160::repeat_byte(0xDE).into(),
+                }),
+            };
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsWithdraw)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+    }
+
+    #[test]
+    fn remote_transact_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            let multilocation = MultiLocation {
+                parents: 1,
+                interior: Junctions::X1(Junction::Parachain(2000u32)),
+            };
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::RemoteTransactNew)
+                        .write(multilocation)
+                        .write(Address::from(Runtime::asset_id_to_address(1_u128)))
+                        .write(U256::from(367))
+                        .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
+                        .write(U256::from(3_000_000_000u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+    }
+
+    #[test]
+    fn reserve_transfer_assets_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            let dest: MultiLocation = MultiLocation {
+                parents: 1,
+                interior: Junctions::Here,
+            };
+
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountId32 {
+                    network: None,
+                    id: H256::repeat_byte(0xF1).into(),
+                }),
+            };
+            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+
+            // H160
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountKey20 {
+                    network: None,
+                    key: H160::repeat_byte(0xDE).into(),
+                }),
+            };
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
+                        .write(vec![Address::from(Runtime::asset_id_to_address(1u128))])
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+
+        for (location, Xcm(instructions)) in take_sent_xcm() {
+            assert_eq!(
+                location,
+                MultiLocation {
+                    parents: 1,
+                    interior: Here
+                }
+            );
+
+            let non_native_asset = MultiAsset {
+                fun: Fungible(42000),
+                id: xcm::v3::AssetId::from(MultiLocation {
+                    parents: 0,
+                    interior: Here,
+                }),
+            };
+
+            assert_matches!(
+                instructions.as_slice(),
+                [
+                    ReserveAssetDeposited(assets),
+                    ClearOrigin,
+                    BuyExecution {
+                        fees,
+                        ..
+                    },
+                    DepositAsset {
+                        beneficiary: MultiLocation {
+                            parents: 0,
+                            interior: X1(_),
+                        },
+                        ..
+                    }
+                ]
+
+                if fees.contains(&non_native_asset) && assets.contains(&non_native_asset)
+            );
+        }
+    }
+
+    #[test]
+    fn reserve_transfer_currency_works() {
+        ExtBuilder::default().build().execute_with(|| {
+            let dest: MultiLocation = MultiLocation {
+                parents: 1,
+                interior: Junctions::Here,
+            };
+
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountId32 {
+                    network: None,
+                    id: H256::repeat_byte(0xF1).into(),
+                }),
+            };
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
+                        .write(vec![Address::from(H160::zero())]) // zero address by convention
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+
+            let beneficiary: MultiLocation = MultiLocation {
+                parents: 0,
+                interior: Junctions::X1(AccountKey20 {
+                    network: None,
+                    key: H160::repeat_byte(0xDE).into(),
+                }),
+            };
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::AssetsReserveTransfer)
+                        .write(vec![Address::from(H160::zero())]) // zero address by convention
+                        .write(vec![U256::from(42000u64)])
+                        .write(beneficiary)
+                        .write(dest)
+                        .write(U256::from(0_u64))
+                        .build(),
+                )
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+        });
+
+        for (location, Xcm(instructions)) in take_sent_xcm() {
+            assert_eq!(
+                location,
+                MultiLocation {
+                    parents: 1,
+                    interior: Here
+                }
+            );
+
+            let native_asset = MultiAsset {
+                fun: Fungible(42000),
+                id: xcm::v3::AssetId::from(MultiLocation {
+                    parents: 0,
+                    interior: X1(Parachain(123)),
+                }),
+            };
+
+            assert_matches!(
+                instructions.as_slice(),
+                [
+                    ReserveAssetDeposited(assets),
+                    ClearOrigin,
+                    BuyExecution {
+                        fees,
+                        ..
+                    },
+                    DepositAsset {
+                        beneficiary: MultiLocation {
+                            parents: 0,
+                            interior: X1(_),
+                        },
+                        ..
+                    }
+                ]
+
+                if fees.contains(&native_asset) && assets.contains(&native_asset)
+            );
+        }
+    }
+
+    #[test]
+    fn test_send_clear_origin() {
+        ExtBuilder::default().build().execute_with(|| {
+            let dest: MultiLocation = MultiLocation {
+                parents: 1,
+                interior: Junctions::X1(Junction::AccountId32 {
+                    network: None,
+                    id: H256::repeat_byte(0xF1).into(),
+                }),
+            };
+            let xcm_to_send = VersionedXcm::<()>::V3(Xcm(vec![ClearOrigin])).encode();
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    EvmDataWriter::new_with_selector(Action::SendXCM)
+                        .write(dest)
+                        .write(Bytes::from(xcm_to_send.as_slice()))
+                        .build(),
+                )
+                // Fixed: TestWeightInfo + (BaseXcmWeight * MessageLen)
+                .expect_cost(100001000)
+                .expect_no_logs()
+                .execute_returns(EvmDataWriter::new().write(true).build());
+
+            let sent_messages = take_sent_xcm();
+            let (_, sent_message) = sent_messages.first().unwrap();
+            // Lets make sure the message is as expected
+            assert!(sent_message.0.contains(&ClearOrigin));
+        })
+    }
 }

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -289,7 +289,7 @@ fn test_send_clear_origin() {
 		precompiles()
 			.prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, 
                 EvmDataWriter::new_with_selector(Action::SendXCM)
-                .write(xcm_to_send)
+                .write(Bytes::from(xcm_to_send.as_slice()))
                 .write(false)
                 .write(U256::from(1_u64))
                 .build(),

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -120,7 +120,6 @@ fn remote_transact_works() {
                     .write(U256::from(367))
                     .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
                     .write(U256::from(3_000_000_000u64))
-                    .write(U256::from(1_u64))
                     .build(),
             )
             .expect_no_logs()
@@ -255,7 +254,7 @@ fn reserve_transfer_currency_works() {
             fun: Fungible(42000),
             id: xcm::v3::AssetId::from(MultiLocation {
                 parents: 0,
-                interior: X1(OnlyChild),
+                interior: X1(Parachain(123)),
             }),
         };
 

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -120,6 +120,7 @@ fn remote_transact_works() {
                     .write(U256::from(367))
                     .write(vec![0xff_u8, 0xaa, 0x77, 0x00])
                     .write(U256::from(3_000_000_000u64))
+                    .write(U256::from(1_u64))
                     .build(),
             )
             .expect_no_logs()


### PR DESCRIPTION
# Pull Request Summary

## Changes 
1. Add SetAppendix instruction in remote_transact() in xcm-precompile after which user can have extra fees deposited to it’s sovereign account instead of asset trap.
2. Add new function `send_xcm()` which allows to send any xcm-message to the destination chain.
3. Add new Struct Multilocation to precompile
```rust
struct Multilocation {
    uint8 parents;
    bytes[] interior;
}
```
This addition helps in getting rid of function overloading for different Account types (AccountId32 and AccountKey20) supported by xcm.

**Check list**
- [X] added unit tests
- [ ] updated documentation
